### PR TITLE
(WIP) Multithreading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static = "1.4.0"
 sexp = "1.1.4"
 itertools = "0.10.3"
 rand = "0.8.4"
+parking_lot = "0.12.0"
 
 [profile.release]
 debug = true # for flamegraphs

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -8,7 +8,8 @@ use serde_json::json;
 use clap::{Parser};
 use serde::Serialize;
 use std::thread;
-use std::sync::{Arc,Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 use std::ops::DerefMut;
 
 // import slicerandom
@@ -929,7 +930,7 @@ pub fn compression_step(
     // });
     // handle.join().unwrap();
 
-    let mut shared_guard = shared.lock().unwrap();
+    let mut shared_guard = shared.lock();
     let shared: &mut SharedMutable = shared_guard.deref_mut();
 
     assert!(shared.worklist.is_empty());
@@ -1106,12 +1107,10 @@ fn derive_inventions(
 
     loop {
 
-
-
         // * CRITICAL SECTION START *
         let wi = {
-            let mut shared_guard = shared.lock().unwrap();
-            let mut shared = shared_guard.deref_mut();
+            let mut shared_guard = shared.lock();
+            let shared = shared_guard.deref_mut();
             let lowest_donelist_utility = shared.lowest_donelist_utility;
             let utility_pruning_cutoff = shared.utility_pruning_cutoff;
             shared.donelist.extend(donelist_buf.drain(..).filter(|done| done.utility > lowest_donelist_utility));


### PR DESCRIPTION
Adds multithreading. Already seems to work.


Guiding idea: we don't want to make any changes that will make it harder to implement new features! That's not worth it. We just want some basic bare bones parallelism that might not be incredibly fast but will give some boost.

Why: if we're trying to do a performance comparison ofc doing some parallelizing makes sense!

Downsides:
* we need to commit to making everything use `Arc` instead of normal references
* who knows if the thread boundary will get annoying when adding future features. My instinct is given that no real issues came up during this implementation, this might actually be a good move to use multithreading. Thankfully this change only needs to affect things starting at `derive_inventions` as we can just convert everything to Arc at that point.

Performance: Using `--threads=1` (the default) seems to give the same performance as usual, while adding more threads  pretty rapidly gives better performance (eg 5x, 10x). `dials.json` drops from 75s to 9s for me (arity 2, 3 iterations) and `nuts-bolts.json` drops from 7s to 1.5s for me. I'm guessing the larger the workloads the more we'll be able to take advantage of threads. Overshooting eg `--threads=30` doesn't seem to do any worse for me though it's not better than using less. Note that along the way I tested the little changes I made to make things multithreading-compatible and they didnt slow down the single theraded case noticably.

I chose to use `parking_lot` as the mutex crate, though it seems at least on my machine that didn't speed anything up. My impression is that the standard library can be slow on some machines though so I think it makes sense to use `parking_lot` (a crate that they'll probably merge into std at some point).

Todos:
- [ ] clean up and comment things, I did this pretty quick
- [ ] decide how to handle Stats. Probably we should have a --stats option to turn it on, and when it's on then threads will need to do mutex unlocks to modify it. Also have it default to be turned on in the single threaded case since it wont slow it down anyways (itll still have to grab the lock but itll have no competition). Probably even in the competitive case the lock will be grabbed for so little time that it wont be a major slowdown.



