### PR TITLE
no toplevel abstractions in inventions so that HOFs now always take lams

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -471,12 +471,17 @@ fn get_appzippers(treenodes: &[Id], no_cache:bool, egraph: &mut EGraph) -> HashM
         all_appzippers.insert(*treenode, appzippers);
     }
 
-    // remove all the identity functions.
     // note that we must be very careful pruning here. Most pruning isnt allowed, for example you cant prune things
     // that have free variables out bc if those free vars are on the leading edge you could still merge them away later
     all_appzippers.iter_mut().for_each(|(_,appzippers)| {
-        appzippers.retain(|appzipper| !appzipper.zipper.path.is_empty());
-    });
+        appzippers.retain(|appzipper|
+            !appzipper.zipper.path.is_empty() // no identity function
+            // no toplevel abstraction. This is to mirror dreamcoder and so that
+            // rewritten programs actually are things that a top down search could find,
+            // in particular because when you come across an arrow typed hole in top down
+            // search (eg a HOF argument) you autogenerate lambdas and then go into the body.
+            && appzipper.zipper.path[0] != ZNode::Body 
+        )});
 
     all_appzippers
 }


### PR DESCRIPTION
No toplevel abstractions in inventions, ie the top node of the invention cant be `lam`. This is to mirror dreamcoder and so that rewritten programs actually are things that a top down search could find, in particular because when you come across an arrow typed hole in top down search (eg a HOF argument) you autogenerate lambdas and then go into the body.

It does mean that some functions now need to take $0 in as an extra argument which means some functions now must be higher arity so costs are a bit different. This only really affects domains wiht variables (eg logo but not nuts-bolts) and seems to have a fairly small effect.

Command: `cargo run --release --bin=compress data/logo/train_200.json -i5 -t5`

Before:
```
=======Compression Summary=======
Found 5 inventions
Cost Improvement: (2.57x better) 498883 -> 194026
inv0 (1.26x wrt orig): utility: 103157 | final_cost: 394660 | 1.26x | uses: 147 | body: [inv0 arity=2: (logo_forLoop #0 (lam (lam (logo_FWRT (logo_MULL logo_UL #1) (logo_DIVA logo_UA #0) $0))))]
inv1 (1.56x wrt orig): utility: 74204 | final_cost: 319237 | 1.24x | uses: 93 | body: [inv1 arity=2: (lam (logo_forLoop #0 (lam (lam (logo_GETSET #1 (logo_FWRT logo_ZL (logo_DIVA logo_UA #0) $0)))) $0))]   inv2 (2.00x wrt orig): utility: 68249 | final_cost: 249925 | 1.28x | uses: 114 | body: [inv2 arity=1: (logo_forLoop logo_IFTY (lam (lam (logo_FWRT (logo_MULL logo_epsL #0) logo_epsA $0))))]
inv3 (2.37x wrt orig): utility: 38609 | final_cost: 210709 | 1.19x | uses: 129 | body: [inv3 arity=1: (logo_PT (lam (logo_FWRT #0 logo_ZA $0)))]
inv4 (2.57x wrt orig): [cost mismatch] utility: 13196 | final_cost: 194026 | 1.09x | uses: 18 | body: [inv4 arity=2: (inv1 #0 (lam (inv3 logo_UL (logo_FWRT logo_UL logo_ZA (inv3 logo_UL (#1 $0))))))]
Time: 836ms
```

After
```
=======Compression Summary=======
Found 5 inventions
Cost Improvement: (2.45x better) 498883 -> 203512
inv0 (1.26x wrt orig): utility: 103157 | final_cost: 394660 | 1.26x | uses: 147 | body: [inv0 arity=2: (logo_forLoop #0 (lam (lam (logo_FWRT (logo_MULL logo_UL #1) (logo_DIVA logo_UA #0) $0))))]
inv1 (1.53x wrt orig): utility: 68249 | final_cost: 325348 | 1.21x | uses: 114 | body: [inv1 arity=1: (logo_forLoop logo_IFTY (lam (lam (logo_FWRT (logo_MULL logo_epsL #0) logo_epsA $0))))]
inv2 (1.92x wrt orig): utility: 64871 | final_cost: 259411 | 1.25x | uses: 93 | body: [inv2 arity=2: (logo_forLoop #0 (lam (lam (logo_GETSET #1 (logo_FWRT logo_ZL (logo_DIVA logo_UA #0) $0)))))]
inv3 (2.27x wrt orig): utility: 38609 | final_cost: 220195 | 1.18x | uses: 129 | body: [inv3 arity=1: (logo_PT (lam (logo_FWRT #0 logo_ZA $0)))]
inv4 (2.45x wrt orig): [cost mismatch] utility: 13196 | final_cost: 203512 | 1.08x | uses: 18 | body: [inv4 arity=2: (inv2 #0 (lam (inv3 logo_UL (logo_FWRT logo_UL logo_ZA (inv3 logo_UL (#1 $0))))))]
Time: 669ms
```

ie for -i5 the compressivity was 2.45x instead of 2.57x

