### PR TITLE
(wip) Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ flamegraph.svg
 .DS_Store
 
 out/
+
+bindings/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Matt Bowers <mlbowers@mit.edu>", "Theo Olausson <theoxo@mit.edu>"]
 edition = "2018"
 license = "MIT"
 
+[[example]]
+name = "stitch"
+crate-type = ["cdylib"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -24,6 +28,10 @@ itertools = "0.10.3"
 rand = "0.8.4"
 parking_lot = "0.12.0"
 colorful = "0.2.1"
+
+[dependencies.pyo3]
+version = "0.16.1"
+features = ["extension-module"]
 
 [profile.release]
 debug = true # for flamegraphs

--- a/examples/stitch.rs
+++ b/examples/stitch.rs
@@ -1,20 +1,101 @@
 use stitch::*;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
+use std::collections::HashMap;
 
 
+/// Runs compression
+#[pyfunction(
+    programs,
+    "*",
+    iterations = "3",
+    max_arity = "2",
+    threads = "1",
+    inv_candidates = "1",
+    fifo_worklist = "false",
+    ascending_worklist = "false",
+    lossy_candidates = "false",
+    no_cache = "false",
+    show_rewritten = "false",
+    no_opt_free_vars = "false",
+    no_opt_single_use = "false",
+    no_opt_upper_bound = "false",
+    no_opt_force_multiuse = "false",
+    no_opt_useless_abstract = "false",
+    no_stats = "false",
+)]
+fn compression(
+    py: Python,
+    programs: Vec<String>,
+    iterations: usize,
+    max_arity: usize,
+    threads: usize,
+    inv_candidates: usize,
+    fifo_worklist: bool,
+    ascending_worklist: bool,
+    lossy_candidates: bool,
+    no_cache: bool,
+    show_rewritten: bool,
+    no_opt_free_vars: bool,
+    no_opt_single_use: bool,
+    no_opt_upper_bound: bool,
+    no_opt_force_multiuse: bool,
+    no_opt_useless_abstract: bool,
+    no_stats: bool) -> HashMap<String,String> {
 
+    let cfg = CompressionStepConfig {
+        max_arity,
+        threads,
+        inv_candidates,
+        fifo_worklist,
+        ascending_worklist,
+        lossy_candidates,
+        no_cache,
+        show_rewritten,
+        no_opt_free_vars,
+        no_opt_single_use,
+        no_opt_upper_bound,
+        no_opt_force_multiuse,
+        no_opt_useless_abstract,
+        no_stats,
+    };
+
+    let programs: Vec<Expr> = programs.iter().map(|p| p.parse().unwrap()).collect();
+    println!("{}","**********".blue().bold());
+    println!("{}","* Stitch *".blue().bold());
+    println!("{}","**********".blue().bold());
+    programs_info(&programs);
+
+    let programs: Expr = Expr::programs(programs);
+    
+    py.allow_threads(||
+        unimplemented!()
+    )
+}
 
 /// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
+// #[pyfunction(
+//     a,
+//     "*",
+//     b = "10",
+//     c = "10",
+// )]
+// #[pyo3(text_signature = "(a, *, b, c)")]
+// fn soot(a: usize, b: usize) -> PyResult<String> {
+//     Ok((a + b).to_string())
+// }
+
+/// Formats the sum of two numbers as string.
+// #[pyfunction]
+// fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+//     Ok((a + b).to_string())
+// }
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn stitch(py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
-
+fn stitch(_py: Python, m: &PyModule) -> PyResult<()> {
+    // m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+    // m.add_function(wrap_pyfunction!(soot, m)?)?;
+    m.add_function(wrap_pyfunction!(compression, m)?)?;
     Ok(())
 }

--- a/examples/stitch.rs
+++ b/examples/stitch.rs
@@ -1,0 +1,20 @@
+use stitch::*;
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+
+
+
+
+/// Formats the sum of two numbers as string.
+#[pyfunction]
+fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+    Ok((a + b).to_string())
+}
+
+/// A Python module implemented in Rust.
+#[pymodule]
+fn stitch(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
+
+    Ok(())
+}

--- a/gen_bindings.sh
+++ b/gen_bindings.sh
@@ -1,0 +1,9 @@
+# This script just compiles the python bindings for stitch. While there are nicer ways to properly publish a library,
+# for development purposes this is fine. If you add "path/to/stitch/target/release/" to your python path then 
+# you can import stitch with `import stitch`. You can modify your python path with `sys.path.append("path/to/stitch/bindings/")`
+# or in your ~/.bashrc with `export PYTHONPATH="$PYTHONPATH:path/to/stitch/bindings/"`
+# alternatively, to test the bindings just do `cd bindings && python` and then `import stitch`
+set -e
+mkdir -p bindings
+cargo rustc --release --example=stitch -- -C link-arg=-undefined -C link-arg=dynamic_lookup
+mv target/release/examples/libstitch.dylib bindings/stitch.so


### PR DESCRIPTION
This PR aims to provide an initial set of python bindings for stitch. Instead of publishing to pypi or anything fancy since this is a very in-dev project, we'll have the user manually adjust their $PYTHONPATH to point to the bindings as described in the binding generation script.

- [x] initial building template bindings and `import stitch` in python works
- [x] wrote bindings generation script
- [x] #58  make this change so we can not duplicate a buncha code again
- [x] decide what we want compression API to look like.
- [x] write compression() binding
- [x] use `allow_threads` to unlock the GIL