### PR TITLE
(WIP) 2nd beta inversion by post-search refinement

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -781,10 +781,20 @@ fn compressive_utility_upper_bound(
                 egraph[appzipper_of_node_zid[&(*node,arg_zid)].arg].data.inventionless_cost
             ).sum::<i32>()
         ).sum::<i32>();
+    // EXPERIMENTAL: weaken the upper bound to the point that it gets utility equal to each multiarg. This
+    // likely causes a considerable slowdown but accounts for the fact that we may "refine" an arg to put some
+    // of it back into the invention body for nested search.
+    let global_multiarg_utility = ztuple.multiarg.iter()
+    .map(|&arg_zid| // for each extra use of a multiuse arg
+        nodes.iter().map(|node| // for each node
+            num_paths_to_node[node] * // account for same node being used in multiple subtrees
+            egraph[appzipper_of_node_zid[&(*node,arg_zid)].arg].data.inventionless_cost
+        ).sum::<i32>()
+    ).sum::<i32>();
     // safe bound: number of usage locations will only decrease in offspring inventions
     let num_uses = nodes.iter().map(|node| num_paths_to_node[node]).sum::<i32>();
     // safe bound: summing a bunch of safe bounds is safe
-    num_uses * (app_penalty + left_utility) + global_multiuse_utility + global_right_utility_upper_bound
+    num_uses * (app_penalty + left_utility) + global_multiuse_utility + global_right_utility_upper_bound + global_multiarg_utility
 }
 
 /// This takes a partial invention and gives an upper bound on the maximum

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{self, Formatter, Display};
 use std::hash::Hash;
 use itertools::Itertools;
@@ -810,6 +810,21 @@ fn other_utility_upper_bound(
     structure_penalty
 }
 
+/// https://github.com/mlb2251/stitch/pull/83
+fn second_beta_inversion_refinement(done: &mut FinishedItem) {
+    let descendants_of_node: HashMap<Id,HashSet<Id>> = unimplemented!();
+    for arg in done.ztuple.multiarg.iter() {
+        // make a list of the possible args we could move into the invention body to refine it
+        let possible_args: HashSet<Id> = done.nodes.iter()
+            .map(|node| descendants_of_node[node].iter().copied())
+            .flatten().collect();
+        for arg in possible_args {
+            let utility_improvement: i32 = unimplemented!();
+            if utility_improvement <= 0 { continue; }
+        }
+    }
+}
+
 /// Multistep compression. See `compression_step` if you'd just like to do a single step of compression.
 pub fn compression(
     programs_expr: &Expr,
@@ -1363,8 +1378,10 @@ fn derive_inventions(
                 let right_utility = right_edge_utility(right_edge_key(&group[0]), &*egraph);
                 let compressive_utility = compressive_utility(left_utility + right_utility, &new_ztuple, &group, &*num_paths_to_node, &*egraph, &*appzipper_of_node_zid);
                 let utility = compressive_utility + other_utility(left_utility + right_utility, &cfg);
-                if utility >= 0 {
-                    donelist_buf.push(FinishedItem::new(new_ztuple.clone(), group, utility, compressive_utility));
+                let mut done = FinishedItem::new(new_ztuple.clone(), group, utility, compressive_utility);
+                second_beta_inversion_refinement(&mut done);
+                if done.utility >= 0 {
+                    donelist_buf.push(done);
                 }
             }
     

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -811,14 +811,20 @@ fn other_utility_upper_bound(
 }
 
 /// https://github.com/mlb2251/stitch/pull/83
-fn second_beta_inversion_refinement(done: &mut FinishedItem) {
-    let descendants_of_node: HashMap<Id,HashSet<Id>> = unimplemented!();
-    for arg in done.ztuple.multiarg.iter() {
+fn second_beta_inversion_refinement(
+    done: &mut FinishedItem,
+    descendants_of_node: &HashMap<Id,HashSet<Id>>,
+    appzipper_of_node_zid: &HashMap<(Id,ZId),AppZipper>,
+) {
+    for multiarg_zid in done.ztuple.multiarg.iter() {
         // make a list of the possible args we could move into the invention body to refine it
         let possible_args: HashSet<Id> = done.nodes.iter()
-            .map(|node| descendants_of_node[node].iter().copied())
-            .flatten().collect();
+            .map(|node| appzipper_of_node_zid[&(*node,*multiarg_zid)].arg) // lookup arg
+            .map(|arg| descendants_of_node[&arg].iter().copied()) // lookup descendents of arg
+            .flatten().collect(); // collect into hashset to dedup
         for arg in possible_args {
+            
+
             let utility_improvement: i32 = unimplemented!();
             if utility_improvement <= 0 { continue; }
         }
@@ -1379,7 +1385,7 @@ fn derive_inventions(
                 let compressive_utility = compressive_utility(left_utility + right_utility, &new_ztuple, &group, &*num_paths_to_node, &*egraph, &*appzipper_of_node_zid);
                 let utility = compressive_utility + other_utility(left_utility + right_utility, &cfg);
                 let mut done = FinishedItem::new(new_ztuple.clone(), group, utility, compressive_utility);
-                second_beta_inversion_refinement(&mut done);
+                second_beta_inversion_refinement(&mut done, unimplemented!(), &appzipper_of_node_zid);
                 if done.utility >= 0 {
                     donelist_buf.push(done);
                 }


### PR DESCRIPTION
Partial solution to #40 

It turns out the inner search required for 2nd beta inversion is far easier than the outer search, because the inner search is about finding a *shared subtree* instead of a *shared scaffold*. Since structural hashers already tell us when the same subtree is in multiple places, this shouldn't be too hard.

We can cast this as a post-search improvement problem, where we raise the upper bound of a partial invention by pretending any multiarg arguments are actually shoved into the body of the invention (overapproximating the fact that this post-improvement will move part of the arg into the body), and this higher upper bound means we can safely put off refining arguments into 2nd-beta-inverted-arguments till the end.

Initial tests of raising the upper bound don't show a huge decrease in runtime - around 2s -> 2.8s or 159 -> 516 partial inventions, and upper bound pruning and single use pruning both still fire a lot. My sense is it just means the search has to unfold partial inventions a bit more before being able to prune them. Certainly this could be a considerable slowdown (eg 50% here) but not an unreasonable one for adding a new very useful feature.

An alternative would be to do this argument refinement *on the spot* which would have the benefit of slightly tightening bounds and letting us find multiuses of these refined arguments, but I don't think it's worth it because it would massively branch the search. It's also not super hard to switch to this from having first implemented the post-refinement appraoch.

The two things dreamcoder does that this would not capture are
* when it does 3 beta inversions within the same argument. I have trouble visualizing what that even means. My guess is it's not important. Regardless I'll have a better understanding after I finish this implementation, so it might be more possible to look into then. I would be quite surprised if any DC invention actually uses this.
* when it uses the same higher order function in multiple places (as in, #1 is a function type and it's used multiple places within the body). I suspect this doesnt come up in dreamcoder. Also glancing over the origami domain in the DC paper the inventions dont look like they use this.

## Negative IVars
* When an arg with `$0` as a free var is about to get downshifted during the `Lambda::Lam` branch of `get_appzippers`, we go through and replace variables that reference `$0` with `#-depth` (a negative IVar) where `depth` is the number of lambdas along the zipper to `#0` through the body (excluding the newly added lambda, so that $depth placed at #0 would directly reference this lambda (unless any lambdas were included in the refining-out, in which case that depth would have to be added to the variable too. But that's dealt with during refining out, here you simply do `#-depth`).
* How will this interact with multiuse at the unrefined arg level?
  * It will be fine, ie if two unrefined args are identical (ie multiuse has been done at this level) then the refined args are guaranteed to also be refinable in an identical way so we aren't breaking any multiuse that we've already done. This is because from a given unrefined arg regardless of the context it's used in it's always possible to refine it in exactly the same way, since refinement has nothing to do with context beyond adjusting the index but that's already been captured by the negative ivar and can be calculated without looking at the context.
* How will this interact with multiuse at the refined-out arg level?
  * It will be fine. At the refined-out level multiuse is based on structural hashing, and since `#-i` gets translated to `$(i+refined_out_lambda_depth)` then there should be a one to one correspondance between abstracting out multiple copies of the same thing and those all turning into the same result (ie refining out some subtree always transforms it in the same way regardless of what context it's put into)
* Why negative IVars?
  * we can query free_ivars to see if they're present in a subtree easily
  * they wont get affected by shifting operations which we want in this case
  * they aren't being used for anything and it's hard to imagine them being used for much
  * they wont show up in regular trees only invention trees so we're less likely to affect other code than if we did something like negative Vars
  * theyll only show up in args and since there are never any ivars in args this should not clash with any existing code
  * we dont want to create a new `Lambda::` enum variant for this because that would require dozens of changes to the code.

## Subsuming Context Threading
* This PR would actually subsume context threading and we can remove everything related to context threading (eg `threaded_vars`) and the cfg flags.
* Instead context threading is achieved by just refining out negative variables

## What can / can't be refined out?
* You *cant* refine out a free variables in the arg. This points outside of the invention so it can't be moved into the invention body without creating a free variable in the finished invention (illegal)
* You *cant* refine out a variable referencing a lambda that's within the argument unless youre also refining out that lambda itself, because you can't create a reference to the lambda within the argument from within the body.
* In short, this means you can't refine out any term with free variables. It's okay for the term to have variables as long as they aren't free variables.
* What you **can** refine out: arbitrary subtrees that don't have free variables and may or may not have negative variables
* Useless refinement optimization: it's never worthwhile to refine out a size=1 term (even if it's multiused) unless it's a negative variable.
* It's always better to maximally multiuse the refinement arg, ie if it appears multiple times you should refine out all of them not just one.

## What should refinement output?
* metadata on the `ZTuple` thats a list of list of refined out args. This is a good place because to_expr can use it and we no longer need the threaded vars on labelledzids etc.

## Higher arity refinements
* `--refinement_arity` can control the number of terms refined out
* This isn't super clear yet but there are various thoughts:
  - For multiarg refinement I guess you want to only look for the cousin cases and watch out for usecollision esp if this happens only sometimes.
  - I might just suggest greediness with multiarg - complete the search with one, rewrite the unrefined args using that, do the search for another. Idk that's not optimal ofc.
  - you know a single arg wont collide with itself, and two args will only collide with each other if one is a subtree of the other - right we're working with subtrees where structural hashing makes everything easy!
  - I'm pretty sure the gains are additive between multiarg with subtrees. The only notable thing is some args preclude each other. Oh wait also different args result in different subsets and multiarg means intersecting the subsets.
  - you could potentially still do this though. First map over the arg possibilities to get utilities + subsets for each. Then loop over pairs of args (or triples for arity=3 etc) and abort if one arg is a descendent of another and then just keep track of the best utility youve seen (taking subsets into account). *Dont exactly know how this would work since I haven't seen how utility calc happens / if its actually possible to decouple it from usages*

## Algorithm

- I think we want to have preconstructed a mapping from a parent to all its descendents along with usage counts (+ maybe even multiplied by size so you get real cost).
- Then we build up a hashmap by looping over all these and a) building the `nodes` subset for each of these options (since they all have diff nodes subsets) b) noting the global_hof_utility from this.
- Then we do need to recalculate utility at this point since the nodes subset has changed which changes both num_uses and also the multiuse gains since those are location dependent.
- I think we dont want to fully construct cloned ztuples for each of these things we just want to pick out the best one then create a new ztuple that has it as part of the LabelledZid I guess.


## Todos

- [x] undo threading
- [ ] what exactly does the utility formula become?
- [ ] how will we write `rewrite_with_invention`?
- [ ] how will we write `ZTuple::to_expr`? This much should be super easy we can have `start_ivar()` handle it.
- [ ] (later) If we really wanted to obey `--inv-candidates` we could return a bunch of candidates from this. Maybe we should read the `inv-candidates` thing for how many to return.
- [ ] Use-conflicts within the `refinement_arity` args is easy, but what about use-conflicts that come from the act of refining since it damages the existing arg? Remember we'll have use-conflict checks before merging the donelist_buf into the donelist, but I guess the fear is what if we drop those alternatives during refinement because we found one that we thought was great but it turns out to not be good... Idk, should we be building up a list since we might want it for inv-candidates anyways? idk.
- [ ] do this in `initial_inventions` too






