### PR TITLE
Use-conflict checks

### DIFF
--- a/src/egraphs.rs
+++ b/src/egraphs.rs
@@ -5,11 +5,11 @@ use std::collections::{HashMap, HashSet};
 
 pub type EGraph = egg::EGraph<Lambda, LambdaAnalysis>;
 
-#[derive(Default)]
+#[derive(Default,Clone,Debug)]
 pub struct LambdaAnalysis;
 
 /// The analysis data associated with each Lambda node
-#[derive(Debug)]
+#[derive(Debug,Clone)]
 pub struct Data {
     pub free_vars: HashSet<i32>, // $i vars. For example (lam $2) has free_vars = {1}.
     pub free_ivars: HashSet<i32>, // #i ivars

--- a/src/egraphs.rs
+++ b/src/egraphs.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 
 use crate::*;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque, BTreeSet};
 
 pub type EGraph = egg::EGraph<Lambda, LambdaAnalysis>;
 
@@ -136,16 +136,32 @@ impl CostFunction<Lambda> for ProgramDepth {
 }
 
 
-/// does a child first traversal of the egraph and returns a Vec<Id> in that
-/// order. Notably an Id will never show up twice (if it showed up earlier
-/// it wont show up again). Assumes no cycles in the EGraph.
-/// Note that I'm pretty usre this will just return 0,1,2,3,... since due to structural
-/// hashing that is a topological ordering
+/// Constructs the set of all descendents of `root`, then just sorts that as a vector
+/// since we know since children were always added before parents to the egraph, children
+/// always have lower numbers.
 pub fn topological_ordering(root: Id, egraph: &EGraph) -> Vec<Id> {
+    // let mut worklist = vec![root];
+    // let mut seen = Vec::with_capacity(egraph[root]);
+
+    // while let Some(id) = worklist.pop() {
+    //     if seen.contains(&id) { continue; }
+    //     seen.push(id);
+    //     for child in egraph[id].nodes[0].children() {
+    //         worklist.push(*child);
+    //     }
+    // }
+    // seen.sort();
+    // seen.dedup();
+    // seen
+
+    // let mut res: Vec<Id> = seen.into_iter().collect();
+    // res.sort();
     let mut vec = Vec::new();
+
     topological_ordering_rec(root, egraph, &mut vec);
     // let alt = (0..=usize::from(root)).collect::<Vec<usize>>().into_iter().map(|x| Id::from(x)).collect::<Vec<Id>>();
     // assert_eq!(vec, alt);
+    // res
     vec
 }
 

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -2,8 +2,6 @@ use crate::*;
 use std::collections::{HashMap, HashSet};
 use compression::*;
 
-
-
 /// convert an egraph Id to an Expr. Assumes one node per class (just picks the first node). Note
 /// that this could cause an infinite loop if the egraph didnt just have a single node in a class
 /// and instead the first node had a self loop.
@@ -108,10 +106,11 @@ pub fn rewrite_with_invention_egraph(
 /// actually do any rewriting.
 pub fn rewritten_cost(
     root: Id,
-    inv: &Invention,
+    inv_body: &Expr,
+    inv_arity: usize,
     egraph: &mut EGraph
 ) -> i32 {
-    let inv_ptr: PtrInvention = PtrInvention::new(egraph.add_expr(&inv.body.clone().into()), inv.arity);
+    let inv_ptr: PtrInvention = PtrInvention::new(egraph.add_expr(inv_body.into()), inv_arity);
     nodecosts(root, &inv_ptr, egraph)[&root].cost
 }
 


### PR DESCRIPTION
Addressing #37.

Why: Currently the system is slightly unsound bc we may overestimate the number of places an invention is useful (since we dont capture conflicts) which will boost our best_invention_so_far which will cause us to overprune.

This PR takes the following approach: before merging `donelist_buf` into `donelist`, calculate the true bottom up useconflict-aware costs of everything using a new api method `extraction::rewritten_cost()`. Then we can re-filter these for upper bound pruning before adding them to the true set of finisheditems. `FinishedItem` will be updated to hold the true utility at this time as well.

The hope is that we dont actually complete inventions that often (eg `1737` in nuts-bolts, `2711` in dials, `540` in logo) so this slowdown wont be a big deal. Furthermore a bottom up approach probably isnt actually that slow and we can speed it up a bit too.

One fear is we do need to run `to_expr` and feed an expression into `rewritten_cost()`. I think that this may cost a little bit but is probably the right move because we really really really dont want a separate version that operates on ztuples if thats even possible, and it might be a negligible slowdown anyways.


### Performance issues
* logo started taking 22s instead of 1.5s. I noticed 60% of that was due to `toplogical_ordering_rec` which was being called by `threadables_of_inv` repeatedly. Commenting that out (only briefly since it breaks threading) brought it down to 8s but that's still rough, and 65% of the time was spent in `nodecosts()`. About a third of that was in `match_expr_with_inv_rec` but then again of course thats where the bulk of the challenge of matching is as well.
* Part of me wants to convert these recursive functions to worklists so we stop having these gross towers in the flamegraph, however it's not clear that that's really the issue here.
* Converting `toplogical_ordering_rec` to a worklist was not a good move, it actually slowed it down another 2x. BTreeSet brought it back to 1.5x.
* Okay, so this was an important experiment and it seems like the conclusion is that bottom up as it stands now is *not* so cheap that you could casually run it all the time. So given that there are a variety of options:
  1. Come up with a new very fast rewriter. I sortof doubt this because bottom up already seemed fast in theory but its not fast compared to the rest of the pipeline. I feel like a really good rewriter would be basically what we're already doing with partial inventions. **lean towards NOT doing this**
  2. Come up with a fast way to identify use-conflicts for a finisheditem - just detecting and not even deciding will probably massively decrease the number of hits. I can actually measure whether this is true, so i'll do that.
    * it looks like `cost_mismatch_fired: 697, exact_cost_calculated: 3177` so in logo, you could call this 4.5x less often which indeed would be hugely beneficial. Not to mention im not even sure that all those firings are due to conflicts and not just random minor off by X errors. Ya with ctx_threading off we have cost_mismatch_fired: 68, exact_cost_calculated: 2548 so thats a 38x speedup. You could prob even modify this to tell you the number of cases that truly have conflicts (just by doing the full rewrite instead of just asking for the cost and then searching for "inv0"). -> confirmed those 68 were usage mismatches.
    * **okay with doing this if we cant do (3)**
  3. Come up with a fast way to identify THEN decide use-conflicts for a finisheditem.
      * ok so step one would be to have a method for checking if a pair of usage locations (where one is higher than the other so you know its a potential parent) will conflict. Think of each usage location as a node and draw undirected edges between nodes that conflict.
      * remember this is always the *same* invention conflicting with itself so it cant like reach over itself completely or anything. It can apply within its own argument.
      * I wonder if you could do it from knowing the list of nodes along a zipper at a node and checking for the other root in that? Or looking at each zipper endpoint arg and seeing if its a descendant of the upper invention. 
      * Remember precompute as much as you can! It's probably fine to precompute the path / path length between any 2 nodes (n^2 paths of length depth at most). Or something else like that that makes it easy to decide this. Also prob very important to skip computation as fast as possible eg when two nodes are so far apart or so close they couldnt possibly conflict then youre fine.


Todo:
- [x] factored out into separate `nodecosts()` fn so ew can loop into that using `rewritten_cost()`
- [x] simplify `NodeCost` so actually just be a single i32 since we dont need to be doing everything with a hashmap of invs
- [x] calculate true utility for finisheditems!
- [ ] (out of scope for this PR) at some point we'll need to update our `nodecosts()` to be able to handle not just threading but true 2nd-beta-inv inventions. 
- [x] adjust my calculation of other_utility i made it really approximate idk if it's right!
- [ ] Transfer the notes from above in this PR about Performance issues and potential solutions into a new Issue
- [ ] Adjust my code so it optionally runs when you turn a flag on
- [ ] Make sure my changes are compatible with `bin/rewrite.rs`, get example command from slack that cathy sent theo and put in readme for future ref
- [ ] Read over this PR to clean up any code I'm about to merge
- [ ] adapt to changes on main from https://github.com/mlb2251/stitch/pull/89
- [ ] merge to main - so we have this better cost stuff around



