### PR TITLE
bugfix on nested invention call extraction and automatic #(lambda rewriting

### DIFF
--- a/data/dc/logo_iteration_1.json
+++ b/data/dc/logo_iteration_1.json
@@ -1,0 +1,3127 @@
+{
+    "arity": 3,
+    "topK": 2,
+    "pseudoCounts": 30.0,
+    "aic": 1.0,
+    "bs": 1000000,
+    "topI": 300,
+    "structurePenalty": 1.5,
+    "CPUs": 1,
+    "lc_score": 0.0,
+    "DSL": {
+        "logVariable": -0.5229609747639952,
+        "productions": [
+            {
+                "expression": "#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0)))",
+                "logProbability": -1.194253007668455
+            },
+            {
+                "expression": "#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0)))",
+                "logProbability": -1.2241947071035146
+            },
+            {
+                "expression": "#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA)",
+                "logProbability": -1.194294806228017
+            },
+            {
+                "expression": "#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL)",
+                "logProbability": -1.2548761561124202
+            },
+            {
+                "expression": "#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0)))))))",
+                "logProbability": -1.2241045210438752
+            },
+            {
+                "expression": "#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0)))",
+                "logProbability": -1.2241126972801237
+            },
+            {
+                "expression": "#(logo_DIVA logo_UA 4)",
+                "logProbability": -0.3416622335634898
+            },
+            {
+                "expression": "#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0)))))))",
+                "logProbability": -1.171622916115818
+            },
+            {
+                "expression": "#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0)))))",
+                "logProbability": -1.2548877826398974
+            },
+            {
+                "expression": "logo_UA",
+                "logProbability": -0.44982253709538655
+            },
+            {
+                "expression": "logo_UL",
+                "logProbability": -0.3158216977040915
+            },
+            {
+                "expression": "logo_ZA",
+                "logProbability": -0.5284262929641756
+            },
+            {
+                "expression": "logo_ZL",
+                "logProbability": -0.6923460851099907
+            },
+            {
+                "expression": "logo_DIVA",
+                "logProbability": -0.5203525259837694
+            },
+            {
+                "expression": "logo_MULA",
+                "logProbability": -0.5378584310042998
+            },
+            {
+                "expression": "logo_DIVL",
+                "logProbability": -0.7045696594366047
+            },
+            {
+                "expression": "logo_MULL",
+                "logProbability": -0.6244218733654003
+            },
+            {
+                "expression": "logo_ADDA",
+                "logProbability": -0.6037185152027194
+            },
+            {
+                "expression": "logo_SUBA",
+                "logProbability": -0.5837589818955347
+            },
+            {
+                "expression": "logo_PT",
+                "logProbability": -1.253826147208239
+            },
+            {
+                "expression": "logo_FWRT",
+                "logProbability": -1.002277259608618
+            },
+            {
+                "expression": "logo_GETSET",
+                "logProbability": -1.2846644785784305
+            },
+            {
+                "expression": "logo_IFTY",
+                "logProbability": -0.77712850943526
+            },
+            {
+                "expression": "logo_epsA",
+                "logProbability": -0.5013542799922117
+            },
+            {
+                "expression": "logo_epsL",
+                "logProbability": -0.679779974067368
+            },
+            {
+                "expression": "logo_forLoop",
+                "logProbability": -1.164131943667301
+            },
+            {
+                "expression": "0",
+                "logProbability": -0.810254240210694
+            },
+            {
+                "expression": "1",
+                "logProbability": -0.810254240210694
+            },
+            {
+                "expression": "2",
+                "logProbability": -0.6571419724198981
+            },
+            {
+                "expression": "3",
+                "logProbability": -0.6491988550881267
+            },
+            {
+                "expression": "4",
+                "logProbability": -0.5585835541853199
+            },
+            {
+                "expression": "5",
+                "logProbability": -0.6333628016939432
+            },
+            {
+                "expression": "6",
+                "logProbability": -0.7456611706774665
+            },
+            {
+                "expression": "7",
+                "logProbability": -0.7090575095588703
+            },
+            {
+                "expression": "8",
+                "logProbability": -0.726663063119362
+            },
+            {
+                "expression": "9",
+                "logProbability": -0.7457121284222921
+            }
+        ],
+        "continuationType": {
+            "constructor": "turtle",
+            "arguments": []
+        }
+    },
+    "iterations": 20,
+    "frontiers": [
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3-gon (*d 1l 2)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_MULA (logo_DIVA logo_UA 3) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 2) 4) (logo_DIVA logo_UA 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_MULA (logo_DIVA logo_UA 9) 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 4) 8) (logo_DIVA logo_UA 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "4-gon (*d 1d 4)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_DIVA logo_UA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "5-gon (*d 1d 2)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 2) 4) (logo_DIVA logo_UA 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_ADDA (logo_DIVA logo_UA 5) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "7-gon (*d 1d 3)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 3) (logo_ADDA (logo_DIVA logo_UA 7) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 3) (logo_MULA (logo_SUBA logo_UA (logo_DIVA logo_UA 7)) 6) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 2) 6) (logo_DIVA logo_UA 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 3) (logo_DIVA logo_UA 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 3) (logo_SUBA (logo_DIVA logo_UA 7) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "Greek spiral 6",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_SUBA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_MULA (logo_SUBA (logo_DIVA logo_UA 4) logo_UA) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_DIVA logo_UA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "Greek spiral 9",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 9 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 9 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_MULA (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 9 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_DIVA logo_UA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 9 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_SUBA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 9 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "smooth spiral 2",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $1) (logo_DIVA logo_UA logo_IFTY) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $1) (logo_ADDA logo_epsA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "smooth spiral 4",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $1) (logo_MULA logo_epsA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $1) (logo_MULA (logo_SUBA logo_epsA logo_UA) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $1) (logo_SUBA (logo_DIVA logo_UA 8) logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "star 3",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 3) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 3) 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 6) 8) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_DIVA logo_UA 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 9) 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "star 7",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_SUBA logo_ZA (logo_DIVA logo_UA 7)) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_SUBA logo_UA (logo_MULA (logo_DIVA logo_UA 7) 4)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_SUBA logo_ZA (logo_MULA (logo_DIVA logo_UA 7) 4)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 7) 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_SUBA logo_UA (logo_DIVA logo_UA 7)) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_UA logo_epsA) $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA $0))) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA (logo_FWRT logo_epsL (logo_SUBA logo_epsA logo_epsA) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_ZA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_UA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_ZA logo_epsA) $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA $0))) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 2",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_ADDA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_SUBA (logo_DIVA logo_UA logo_IFTY) logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_SUBA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_SUBA logo_ZA (logo_SUBA logo_ZA logo_epsA)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) logo_epsA $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 2",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) logo_epsA $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_ADDA logo_epsA logo_UA) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) (logo_ADDA logo_epsA logo_UA) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_DIVL (logo_DIVL logo_UL 2) 5) logo_epsA $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 2) logo_epsA $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 3",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 3) (logo_SUBA logo_UA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 3) (logo_SUBA (logo_MULA (logo_SUBA logo_epsA logo_epsA) 4) logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 3) (logo_SUBA logo_ZA (logo_ADDA logo_epsA logo_UA)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 3) (logo_SUBA logo_ZA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 3) (logo_SUBA logo_UA (logo_ADDA logo_epsA logo_UA)) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 4",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 4) (logo_SUBA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 5) logo_epsA $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 4) (logo_SUBA (logo_DIVA logo_UA logo_IFTY) logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 4) logo_epsA $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 4) (logo_ADDA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 5",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 4) (logo_SUBA logo_ZA (logo_ADDA logo_epsA logo_UA)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 4) (logo_SUBA logo_ZA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 4) (logo_SUBA logo_UA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 5) (logo_SUBA logo_ZA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 5) (logo_SUBA logo_UA logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 6",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 6) (logo_SUBA logo_ZA (logo_SUBA logo_ZA logo_epsA)) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 6) (logo_SUBA (logo_DIVA logo_UA logo_IFTY) logo_epsA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 6) logo_epsA $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 6) (logo_SUBA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT (logo_MULL logo_epsL 6) (logo_ADDA logo_epsA logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "6 enclosed circles",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $5) logo_epsA $0))) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL $5) logo_epsA $0))) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "1-semicircle sequence L=1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_ZA logo_epsA) $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA $0))) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_UA logo_epsA) $0))) (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_ZL logo_epsA $0))) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_UA logo_epsA) $0))) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_ZA logo_epsA) $0))) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL (logo_SUBA logo_UA logo_epsA) $0))) (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA $0))) $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "row of 3 lines",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_epsL logo_IFTY) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0))))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_FWRT (logo_DIVL logo_UL 2) logo_UA $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT (logo_MULL logo_epsL logo_IFTY) logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "4 dashed lines of size (/d 1d 3)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 3) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 6) 2) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 3) logo_UA (logo_PT (lambda (logo_FWRT (logo_MULL logo_epsL logo_IFTY) logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 3) logo_UA (logo_PT (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_FWRT (logo_DIVL logo_UL 2) logo_UA $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 3) logo_UA (logo_PT (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_PT (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA $0)) $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3-empty snowflake",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 7) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 5) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_epsA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 9) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 8) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "5-empty snowflake",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 8) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 5) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 7) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 5) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 7) $0)) (logo_FWRT logo_ZL (logo_MULA logo_epsA 8) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_epsA $0)) (logo_FWRT logo_ZL (logo_MULA logo_epsA 8) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_epsA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 5) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "6-empty snowflake",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 7) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_epsA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 8) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_UA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 5) $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "2x2 grid",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 4) (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 4) $0))) (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 4) $0)) (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 4) $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 4) (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 4) $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL (logo_DIVA logo_UA 4) (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_DIVA logo_UA 4) $0))))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL 2) (logo_DIVA logo_UA 4) $0)) (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL (logo_DIVL logo_UL 2) 2) (logo_DIVA logo_UA 4) $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square of size 4",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_DIVA logo_UA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 4) (logo_MULA (logo_DIVA logo_UA 4) 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square of size 5",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 5) (logo_DIVA logo_UA 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 5) (logo_MULA (logo_DIVA logo_UA 4) 7) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 5) (logo_MULA logo_epsA 9) (logo_FWRT logo_ZL logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 5) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL 5) logo_epsA (logo_FWRT logo_ZL (logo_MULA logo_epsA 9) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "7-concentric squares",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) (logo_DIVA logo_UA 4) (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $3) (logo_DIVA logo_UA 4) $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $3) (logo_ADDA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $3) (logo_DIVA logo_UA 4) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $3) (logo_SUBA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $3) (logo_MULA (logo_DIVA logo_UA 4) 9) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3-gon 1l slanted 8",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA logo_ZL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 3 logo_UL $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "4-gon (*d 1d 3)",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL logo_UL 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) (logo_MULL logo_UL 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL 1) 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL 3) 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_DIVL logo_UL 3) 9) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "5-gon 1l",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 5 logo_UL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_MULA logo_epsA 8) logo_UL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda $0) (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_MULA logo_epsA 8) logo_UL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 5 logo_UL $0)) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_MULA logo_epsA 8) logo_UL $0)) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "6-gon (*d 1d 2) slanted 5",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 8 logo_epsA logo_ZL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 6 (logo_MULL logo_UL 2) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_ZL logo_epsA 8 (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 6 (logo_MULL logo_UL 2) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL (logo_DIVA logo_UA 5) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 6 (logo_MULL logo_UL 2) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 5) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 6 (logo_MULL logo_UL 2) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL (logo_MULA logo_epsA 8) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 6 (logo_MULL logo_UL 2) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "7-gon 1l",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 7 logo_UL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 7 (logo_MULL logo_UL 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 7 (logo_DIVL logo_UL 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 7 logo_UL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_ZL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 7 logo_UL (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_ZL $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "8-gon (/d 1d 2)",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 8 (logo_DIVL logo_UL 2) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 8 (logo_MULA logo_epsA 5) (logo_DIVL logo_UL 2) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 8 (logo_DIVL logo_UL 2) (logo_GETSET (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 8 (logo_DIVL logo_UL 2) (logo_PT (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) (logo_DIVA logo_UA 8) (logo_PT (lambda $0) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "upwards",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 2 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_UA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_epsA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_ZA $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right angle",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT (logo_MULL logo_UL 2) #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_UA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT (logo_MULL logo_UL 2) #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_ZA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT (logo_MULL logo_UL 2) #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_epsA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_UL (logo_DIVA (logo_MULA logo_UA $1) 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_UL (logo_MULA #(logo_DIVA logo_UA 4) $1) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right angle epsilon",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 #(logo_DIVA logo_UA 4) logo_epsL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL #(logo_DIVA logo_UA 4) (logo_FWRT logo_epsL #(logo_DIVA logo_UA 4) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL #(logo_DIVA logo_UA 4) (logo_FWRT logo_epsL logo_UA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL #(logo_DIVA logo_UA 4) (logo_FWRT logo_epsL logo_epsA $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL #(logo_DIVA logo_UA 4) (logo_FWRT logo_epsL logo_ZA $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "line segment",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_UA $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_ZA $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_epsA $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_ZA (logo_GETSET (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_epsA (logo_GETSET (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square slanted by 2pi/3",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_DIVA #(logo_DIVA logo_UA 4) 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL (logo_DIVA logo_UA 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_DIVA #(logo_DIVA logo_UA 4) 3) (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) logo_UL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL (logo_DIVA logo_UA 3) (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) logo_UL $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "semicircle slanted by 2pi/5",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 7 logo_epsA logo_ZL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 4 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_ZL logo_epsA 7 (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 4 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_MULA logo_epsA 7) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 4 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 8 logo_epsA logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_UL 5) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_ZL logo_epsA 8 (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_UL 5) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "slanted line",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) (logo_MULL logo_UL 3) (logo_DIVA #(logo_DIVA logo_UA 4) 2) 2 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) (logo_MULL logo_UL 3) (logo_MULA logo_epsA 5) 2 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) (logo_MULL logo_UL 3) (logo_DIVA logo_UA 8) 2 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA logo_ZL (logo_FWRT (logo_MULL logo_UL 3) #(logo_DIVA logo_UA 4) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_ZL logo_epsA 5 (logo_FWRT (logo_MULL logo_UL 3) #(logo_DIVA logo_UA 4) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "Greek spiral 7",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 7 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) (logo_MULL logo_UL 1) #(logo_DIVA logo_UA 4) 7 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL (logo_SUBA #(logo_DIVA logo_UA 4) logo_UA) 7 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL (logo_ADDA #(logo_DIVA logo_UA 4) logo_UA) 7 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL (logo_ADDA logo_UA #(logo_DIVA logo_UA 4)) 7 $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "Greek spiral 8",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 8 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 8 (logo_GETSET (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 8 (logo_PT (lambda $0) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) #(logo_DIVA logo_UA 4) (logo_GETSET (lambda $0) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT (logo_MULL logo_UL $1) #(logo_DIVA logo_UA 4) (logo_PT (lambda $0) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "smooth spiral 3",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_MULA logo_epsA 3) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) (logo_DIVL logo_UL logo_IFTY) (logo_MULA logo_epsA 3) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_ADDA (logo_ADDA logo_epsA logo_epsA) logo_epsA) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_ADDA logo_epsA (logo_ADDA logo_epsA logo_epsA)) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_DIVA (logo_SUBA #(logo_DIVA logo_UA 4) logo_epsA) 3) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "smooth spiral 5",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_DIVA logo_UA 8) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_MULA logo_epsA 5) logo_IFTY $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda $0) (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_MULA logo_epsA 5) logo_IFTY $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_DIVA logo_UA 8) logo_IFTY $0)) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_epsL (logo_MULA logo_epsA 5) logo_IFTY $0)) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "star 5",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_DIVA (logo_ADDA logo_UA logo_UA) 5) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_ADDA #(logo_DIVA logo_UA 4) (logo_MULA logo_epsA 6)) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_ADDA (logo_MULA logo_epsA 6) #(logo_DIVA logo_UA 4)) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_MULA (logo_MULA logo_epsA 4) 4) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_MULA (logo_ADDA logo_epsA logo_epsA) 8) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "star 9",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 (logo_DIVA (logo_MULA logo_UA 4) 9) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 (logo_MULA (logo_DIVA logo_UA 9) 4) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 (logo_MULA (logo_ADDA (logo_DIVA logo_UA 9) logo_UA) 4) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 (logo_MULA (logo_SUBA (logo_DIVA logo_UA 9) logo_UA) 4) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 (logo_SUBA (logo_MULA (logo_DIVA logo_UA 9) 4) logo_UA) (logo_MULL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "leaf iteration 1.1",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_ZL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_ZL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_PT (lambda $0) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "leaf iteration 1.2",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT logo_epsL (logo_DIVA logo_UA 2) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 2) (logo_FWRT logo_epsL (logo_DIVA (logo_ADDA logo_UA logo_epsA) 2) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 2) (logo_FWRT logo_epsL (logo_DIVA (logo_SUBA logo_epsA logo_UA) 2) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_MULA logo_epsA 9) logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "leaf iteration 2.1",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (logo_FWRT logo_ZL #(logo_DIVA logo_UA 4) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL #(logo_DIVA logo_UA 4) 1 (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 #(logo_DIVA logo_UA 4) logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_ZL #(logo_DIVA logo_UA 4) 5 (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 9 #(logo_DIVA logo_UA 4) logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_DIVA logo_epsA 2) logo_epsL) $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "staircase 5",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_SUBA logo_UA #(logo_DIVA logo_UA 4)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_SUBA logo_ZA #(logo_DIVA logo_UA 4)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_MULA #(logo_DIVA logo_UA 4) 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_MULA #(logo_DIVA logo_UA 4) 7) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL (logo_MULA (logo_DIVA logo_UA 8) 6) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 8) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_MULA logo_epsA 5) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA logo_ZL (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_MULA logo_epsA 5) (logo_GETSET (lambda $0) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL (logo_MULA logo_epsA 5) (logo_PT (lambda $0) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_epsL logo_epsA (logo_FWRT logo_epsL logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 6 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 7 logo_epsA logo_epsL $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA logo_epsL $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 logo_epsA logo_epsL $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 2",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_UA logo_epsA) (logo_MULL logo_epsL 2) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 2 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL logo_epsA (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 2) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA (logo_FWRT (logo_MULL logo_epsL 2) logo_UA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA (logo_FWRT (logo_MULL logo_epsL 2) logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 3",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda $0) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 3) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_GETSET (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 3) $0)) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_GETSET (lambda $0) (logo_FWRT (logo_MULL logo_epsL 3) logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_PT (lambda $0) (logo_FWRT (logo_MULL logo_epsL 3) logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 3",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) 3 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 6 logo_epsA (logo_MULL logo_epsL 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_MULL logo_epsL 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 logo_epsA (logo_MULL logo_epsL 3) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 4",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_UA logo_epsA) (logo_DIVL logo_UL 5) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_DIVL logo_UL 5) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_UA logo_epsA) (logo_MULL logo_epsL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 4 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL logo_epsA (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_UL 5) $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 4",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) 4 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_DIVL logo_UL 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_MULL logo_epsL 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 logo_epsA (logo_DIVL logo_UL 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "left semicircle of size 5",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 5) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_GETSET (lambda $0) (logo_FWRT (logo_MULL logo_epsL 5) logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_PT (lambda $0) (logo_FWRT (logo_DIVL logo_UL 4) logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_PT (lambda $0) (logo_FWRT (logo_MULL logo_epsL 5) logo_epsA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 5",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_DIVL logo_UL 4) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_DIVL logo_UL 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_MULL logo_epsL 5) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 logo_epsA (logo_DIVL logo_UL 4) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "right semicircle of size 6",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_UA logo_epsA) (logo_MULL logo_epsL 6) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 6 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_ZL logo_epsA (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 6) $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA (logo_FWRT (logo_MULL logo_epsL 6) logo_UA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (logo_FWRT logo_ZL logo_epsA (logo_FWRT (logo_MULL logo_epsL 6) logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle of size 6",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 6) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) 6 $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 6 logo_epsA (logo_MULL logo_epsL 6) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_MULL logo_epsL 6) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop logo_IFTY (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 2 logo_epsA (logo_MULL logo_epsL 6) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "5 enclosed circles",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) $1 $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 logo_epsA (logo_MULL logo_epsL $3) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 5 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 8 (logo_ADDA logo_epsA logo_UA) (logo_MULL logo_epsL $3) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 5 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 8 (logo_SUBA logo_epsA logo_UA) (logo_MULL logo_epsL $3) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 5 (logo_ADDA logo_epsA logo_UA) (logo_MULL logo_epsL $3) $0))) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3-circle flower l=1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT logo_ZL (logo_MULA (logo_DIVA logo_UA 3) 4) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_PT (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_PT (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 3) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3-semicircle sequence L=1",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 1 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_UL logo_IFTY) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 1 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 1) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 1 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL logo_epsL 1) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 1 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 1 $0)))) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_ZL $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "2-semicircle sequence L=2",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 2) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 2 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL (logo_DIVL logo_UL 2) 5) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 2 $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL (logo_DIVL logo_UL 5) 2) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 2 $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "1-semicircle sequence L=3",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL logo_epsL 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 3 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_DIVL (logo_MULL logo_UL 3) logo_IFTY) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 3 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL (logo_DIVL logo_UL logo_IFTY) 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 3 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL (logo_MULL logo_epsL 1) 3) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 3 $0)))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) (logo_MULL (logo_MULL logo_epsL 3) 1) (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY (logo_SUBA logo_ZA logo_epsA) (logo_MULL logo_epsL $0))) 3 $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "row of 2 circles",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 1 logo_UL $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) 1 $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) (logo_MULL logo_epsL $0))) 1 (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "row of 2 lines",
+            "programs": [
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_ZA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (logo_FWRT logo_UL logo_UA $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_FWRT logo_UL logo_ZA (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "3 dashed lines of size (/d 1d 2)",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_UA (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_ZA (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_FWRT (logo_DIVL logo_UL 2) logo_ZA (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 3 (lambda (lambda (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (logo_FWRT (logo_DIVL logo_UL 2) logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "broken circle",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 1 logo_UL $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (#(lambda (lambda (lambda (logo_forLoop $0 (lambda (lambda (logo_FWRT (logo_MULL $4 $1) $3 $0))))))) logo_UL logo_UA 2 $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 2 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "circle next to semicircle",
+            "programs": [
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_ZA $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (logo_forLoop 5 (lambda (lambda (logo_forLoop 8 (lambda (lambda (logo_FWRT $4 logo_epsA $0))) $0))))) logo_epsL (logo_PT (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 1 logo_UL $0)) (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "row of 4 dashes",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL $2) #(logo_DIVA logo_UA 4) $0)) (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL $2) #(logo_DIVA logo_UA 4) $0)) (logo_FWRT (logo_MULL logo_epsL logo_IFTY) #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL $2) #(logo_DIVA logo_UA 4) $0)) (logo_FWRT (logo_MULL (logo_DIVL logo_UL 2) 2) #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL $2) #(logo_DIVA logo_UA 4) $0)) (logo_FWRT (logo_MULL (logo_DIVL logo_UL 3) 3) #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_PT (lambda (logo_FWRT (logo_MULL logo_UL $2) #(logo_DIVA logo_UA 4) $0)) (logo_FWRT (logo_MULL (logo_DIVL logo_UL 4) 4) #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "row of 5 semicircles",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL (logo_PT (lambda (logo_FWRT logo_UL logo_UA (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_epsL $0))) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "7-empty snowflake",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 7) (logo_GETSET (lambda (logo_FWRT logo_UL logo_UA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 7) (logo_GETSET (lambda (logo_FWRT logo_UL logo_ZA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_FWRT logo_ZL (logo_DIVA logo_UA 7) (logo_GETSET (lambda (logo_FWRT logo_UL logo_epsA $0)) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_UA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 7) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 7 (lambda (lambda (logo_GETSET (lambda (logo_FWRT logo_UL logo_ZA $0)) (logo_FWRT logo_ZL (logo_DIVA logo_UA 7) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "4-row of squares",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL (logo_FWRT logo_UL logo_UA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL (logo_FWRT logo_UL logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 1 logo_UL $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) logo_UL (logo_FWRT logo_UL logo_UA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) logo_UL (logo_FWRT logo_UL logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square of size 1",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) logo_UL $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL logo_UL 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_DIVL logo_UL 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) logo_IFTY logo_epsA) logo_ZL (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 logo_UL $0)))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square of size 2",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) (logo_MULL logo_UL 2) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_UA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) (logo_FWRT logo_UL logo_ZA $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL logo_UA (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 4 (lambda (lambda (logo_FWRT logo_UL logo_ZA (logo_FWRT logo_UL #(logo_DIVA logo_UA 4) $0)))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "square of size 3",
+            "programs": [
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL logo_UL 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) (logo_MULL logo_UL 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL 1) 3) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL 3) 1) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_DIVL logo_UL 3) 9) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        },
+        {
+            "request": {
+                "constructor": "->",
+                "arguments": [
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    },
+                    {
+                        "constructor": "turtle",
+                        "arguments": []
+                    }
+                ]
+            },
+            "task": "5-concentric squares",
+            "programs": [
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL logo_UL $1) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) 4 #(logo_DIVA logo_UA 4) (logo_MULL logo_UL $1) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL $1) 1) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_MULL logo_UL 1) $1) $0))) $0))",
+                    "logLikelihood": 0.0
+                },
+                {
+                    "program": "(lambda (logo_forLoop 5 (lambda (lambda (#(lambda (#(lambda (lambda (lambda (logo_forLoop $2 (lambda (lambda (logo_FWRT $2 $3 $0))))))) $0 (logo_DIVA logo_UA $0))) 4 (logo_MULL (logo_DIVL logo_UL 1) $1) $0))) $0))",
+                    "logLikelihood": 0.0
+                }
+            ]
+        }
+    ]
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1094,7 +1094,7 @@ pub fn compression_step(
 
         println!("{}: {}", i, res);
         if cfg.show_rewritten {
-            println!("rewritten: {}", res.rewritten);
+            println!("rewritten:\n{}", res.rewritten.split_programs().iter().map(|p|p.to_string()).collect::<Vec<_>>().join("\n"));
         }
         results.push(res);
         // if args.render_inventions {

--- a/src/egraphs.rs
+++ b/src/egraphs.rs
@@ -54,7 +54,11 @@ impl Analysis<Lambda> for LambdaAnalysis {
             }
             Lambda::Programs(programs) => {
                 // assert no free variables in programs
-                assert!(programs.iter().all(|p| egraph[*p].data.free_vars.is_empty()));
+                for (i,p) in programs.iter().enumerate() {
+                    if !egraph[*p].data.free_vars.is_empty() {
+                        panic!("Assert failed: free vars found in program {}:\n{}\n{:?}", i, extract(*p,egraph), egraph[*p].data.free_vars);
+                    }
+                }
                 assert!(programs.iter().all(|p| egraph[*p].data.free_ivars.is_empty()));
             }
         }

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -370,13 +370,29 @@ fn match_expr_with_inv_rec(
                 root
             } else if egraph[root].data.free_vars.iter().min().unwrap() - depth >= 0 {
                 // 2. `root` has free variables but they all point outside the invention so are safe to decrement
-                let shifted_root = shift(root, -depth, egraph, &mut None).unwrap();
+                
                 // copy the cost of the unshifted node to the shifted node (see PR#1 comments for why this is safe)
-                if !best_inventions_of_treenode.contains_key(&shifted_root) {
-                    let cloned = best_inventions_of_treenode[&root].clone();
-                    best_inventions_of_treenode.insert(shifted_root,cloned);
+                fn shift_and_fix(node: Id, depth: i32, best_inventions_of_treenode: &mut HashMap<Id,NodeCost>, egraph: &mut EGraph) -> Id {
+                    let shifted_node = shift(node, -depth, egraph, &mut None).unwrap();
+                    if best_inventions_of_treenode.contains_key(&shifted_node) {
+                        return shifted_node; // this has already been handled
+                    }
+                    let mut cloned = best_inventions_of_treenode[&node].clone();
+                    // adjust the args needed for the shifted node so that they are shifted too. Note that this
+                    // is only safe because we only ever use this for a single invention at a time so this hashtable
+                    // actually only has one invention in it. This will be adjusted to be way more clear in the use-conflicts
+                    // PR that hasnt yet been merged.
+                    // Note that you propagate down the same "depth" for the shift amount for all recursive calls, I think this is correct
+                    
+                    cloned.inventionful_cost.iter_mut().for_each(|(_key, val)| {
+                        if let Some(args) = &mut val.1 {
+                            args.iter_mut().for_each(|arg| *arg = shift_and_fix(*arg, depth, best_inventions_of_treenode, egraph));
+                        }
+                    });
+                    best_inventions_of_treenode.insert(shifted_node,cloned);
+                    shifted_node
                 }
-                shifted_root
+                shift_and_fix(root, depth, best_inventions_of_treenode, egraph)
             } else {
                 return false // threading needed but this is not a thread site
             };

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -103,6 +103,9 @@ pub fn rewrite_with_invention_egraph(
 
     let treenodes = topological_ordering(root, egraph);
 
+    assert!(!treenodes.iter().any(|n| egraph[*n].nodes[0] == Lambda::Prim(Symbol::from(&inv.name))),
+        "Invention {} already in tree", inv.name);
+
     let mut nodecost_of_treenode: HashMap<Id,NodeCost> = Default::default();
     
     for treenode in treenodes.iter() {
@@ -129,7 +132,8 @@ pub fn rewrite_with_invention_egraph(
         // inventions based on specific node type
         match node {
             Lambda::IVar(_) => { unreachable!() }
-            Lambda::Var(_) | Lambda::Prim(_) => {},
+            Lambda::Var(_) => {},
+            Lambda::Prim(_) => {},
             Lambda::App([f,x]) => {
                 let ref f_nodecost = nodecost_of_treenode[&f];
                 let ref x_nodecost = nodecost_of_treenode[&x];

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -18,10 +18,17 @@ impl InputFormat {
                 // read dreamcoder format
                 let json: serde_json::Value = from_reader(File::open(path).expect("file not found")).expect("json deserializing error");
                 let frontiers = json["frontiers"].as_array().unwrap_or_else(||panic!("json parse error, are you sure you wanted format {:?}?", self));
+                let dsl: Vec<String> = json["DSL"]["productions"].as_array().unwrap().iter().map(|prod|prod["expression"].as_str().unwrap().to_string()).collect();
+                let inv_dc_strs: Vec<(String,String)> = dsl.iter().rev() // rev() since the first dsl function is the newest
+                    .filter(|s| s.starts_with("#")).cloned().enumerate()
+                    .map(|(i,dc_str)| (format!("dc_fn_{}",i),dc_str)).collect();
                 let mut programs: Vec<String> = Vec::default();
                 let mut tasks: Vec<String> = Vec::default();
                 for frontier in frontiers {
-                    let programs_in_frontier: Vec<String> = frontier["programs"].as_array().unwrap().iter().map(|p|p["program"].as_str().unwrap().to_string()).map(|p| p.replace("(lambda ","(lam ")).collect();
+                    let programs_in_frontier: Vec<String> = frontier["programs"].as_array().unwrap().iter().map(|p|p["program"].as_str().unwrap().to_string())
+                        .map(|p| inv_dc_strs.iter().rev().fold(p, |p, s| p.replace(&s.1, &s.0))) // replace #(lambda ...) with fn_2 etc. Start with highest numbered fn to avoid mangling bodies of other fns.
+                        .map(|p| p.replace("(lambda ","(lam ")).collect();
+                    assert!(!programs_in_frontier.iter().any(|p| p.contains("#")));
                     let task: String = frontier["task"].as_str().unwrap().to_string();
                     let task_repeated: Vec<String> = repeat(task).take(programs_in_frontier.len()).collect();
                     programs.extend(programs_in_frontier);


### PR DESCRIPTION
* fixed argument-shifting during extraction for when an invention calls itself within its argument
* added data/dc/logo_iteration_1.json as a realistic file taken from the dreamcoder artifact
* updated formats.rs to handle "#" rewriting for you, it renames things to stuff like dc_fn_1 in order to not conflict with newly found fn_1s
* --show-rewritten is prettier