### PR TITLE
Early ivar assign

### DIFF
--- a/src/egraphs.rs
+++ b/src/egraphs.rs
@@ -206,7 +206,7 @@ fn associate_task_rec(node: Id, egraph: &EGraph, task_id: usize, tasks_of_node: 
 
 /// Does debruijn index shifting of a subtree, incrementing all Vars by the given amount
 #[inline] // useful to inline since callsite can usually tell which Shift type is happening allowing further optimization
-pub fn shift(e: Id, incr_by: i32, egraph: &mut EGraph, cache: &mut Option<RecVarModCache>) -> Option<Id> {
+pub fn shift(e: Id, incr_by: i32, egraph: &mut crate::EGraph, cache: &mut Option<RecVarModCache>) -> Option<Id> {
     let empty = &mut RecVarModCache::new();
     let seen: &mut RecVarModCache = cache.as_mut().unwrap_or(empty);
 

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -7,7 +7,7 @@ use compression::*;
 /// convert an egraph Id to an Expr. Assumes one node per class (just picks the first node). Note
 /// that this could cause an infinite loop if the egraph didnt just have a single node in a class
 /// and instead the first node had a self loop.
-pub fn extract(eclass: Id, egraph: &EGraph) -> Expr {
+pub fn extract(eclass: Id, egraph: &crate::EGraph) -> Expr {
     debug_assert!(egraph[eclass].nodes.len() == 1);
     match &egraph[eclass].nodes[0] {
         Lambda::Prim(p) => Expr::prim(*p),
@@ -70,7 +70,7 @@ pub fn rewrite_with_invention(
     e: Expr,
     inv: &Invention,
 ) -> Expr {
-    let mut egraph = EGraph::default();
+    let mut egraph = crate::EGraph::default();
     let root = egraph.add_expr(&e.into());
     rewrite_with_invention_egraph(root, inv, &mut egraph)
 }
@@ -79,7 +79,7 @@ pub fn rewrite_with_invention(
 pub fn rewrite_with_inventions_egraph(
     root: Id,
     invs: &[Invention],
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
 ) -> Expr {
     let mut root = root;
     for inv in invs.iter() {
@@ -97,7 +97,7 @@ pub fn rewrite_with_inventions_egraph(
 pub fn rewrite_with_invention_egraph(
     root: Id,
     inv: &Invention,
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
 ) -> Expr {
     let inv: PtrInvention = PtrInvention::new(egraph.add_expr(&inv.body.clone().into()), inv.arity, inv.name.clone());
 
@@ -171,7 +171,7 @@ fn extract_from_nodecosts(
     root: Id,
     inv: &PtrInvention,
     nodecost_of_treenode: &HashMap<Id,NodeCost>,
-    egraph: &EGraph,
+    egraph: &crate::EGraph,
 ) -> Expr {
 
     let target_cost = nodecost_of_treenode[&root].cost_under_inv(&inv);
@@ -266,7 +266,7 @@ fn match_expr_with_inv(
     root: Id,
     inv: &PtrInvention,
     best_inventions_of_treenode: &mut HashMap<Id, NodeCost>,
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
 ) -> Option<Vec<Id>> {
     let mut args: Vec<Option<Id>> = vec![None;inv.arity];
     let threadables = threadables_of_inv(inv.clone(), egraph);
@@ -285,7 +285,7 @@ fn match_expr_with_inv_rec(
     args: &mut [Option<Id>],
     threadables: &HashSet<Id>,
     best_inventions_of_treenode: &mut HashMap<Id, NodeCost>,
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
 ) -> bool {
     // println!("comparing:\n\t{}\n\t{}",
     //     extract(root, egraph).to_string(),
@@ -376,7 +376,7 @@ fn match_expr_with_inv_rec(
                 // 2. `root` has free variables but they all point outside the invention so are safe to decrement
                 
                 // copy the cost of the unshifted node to the shifted node (see PR#1 comments for why this is safe)
-                fn shift_and_fix(node: Id, depth: i32, best_inventions_of_treenode: &mut HashMap<Id,NodeCost>, egraph: &mut EGraph) -> Id {
+                fn shift_and_fix(node: Id, depth: i32, best_inventions_of_treenode: &mut HashMap<Id,NodeCost>, egraph: &mut crate::EGraph) -> Id {
                     let shifted_node = shift(node, -depth, egraph, &mut None).unwrap();
                     if best_inventions_of_treenode.contains_key(&shifted_node) {
                         return shifted_node; // this has already been handled
@@ -413,7 +413,7 @@ fn match_expr_with_inv_rec(
     }
 }
 
-fn threadables_of_inv(inv: PtrInvention, egraph: &EGraph) -> HashSet<Id> {
+fn threadables_of_inv(inv: PtrInvention, egraph: &crate::EGraph) -> HashSet<Id> {
     // a threadable is a (app #i $j) or (app <threadable> $j)
     // assert j > k sanity check
     // println!("Invention: {}", inv.to_expr(egraph));

--- a/src/util.rs
+++ b/src/util.rs
@@ -365,3 +365,4 @@ pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGra
     });
     num_paths_to_node
 }
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -226,10 +226,10 @@ pub type RecVarModCache = HashMap<(Id,i32),Option<Id>>;
 /// the enode data that tells us if there are no free variables in a branch (and thus it can be ignored),
 /// it operates on the structurally hashed form of the graph, etc.
 pub fn recursive_var_mod(
-    var_mod: impl Fn(i32, i32, i32, &mut EGraph) -> Option<Id>,
+    var_mod: impl Fn(i32, i32, i32, &mut crate::EGraph) -> Option<Id>,
     ivars: bool,
     eclass:Id,
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
     seen: &mut RecVarModCache
     ) -> Option<Id>
     {
@@ -245,11 +245,11 @@ pub fn recursive_var_mod(
 
 /// see `recursive_var_mod`
 fn recursive_var_mod_helper(
-    var_mod: &impl Fn(i32, i32, i32, &mut EGraph) -> Option<Id>,
+    var_mod: &impl Fn(i32, i32, i32, &mut crate::EGraph) -> Option<Id>,
     ivars: bool, // whether to run this on vars or ivars
     eclass:Id,
     depth: i32,
-    egraph: &mut EGraph,
+    egraph: &mut crate::EGraph,
     seen : &mut RecVarModCache,
     ) -> Option<Id>
     {
@@ -348,12 +348,12 @@ pub fn group_by_key<T: Copy, U: Ord>(v: Vec<T>, key: impl Fn(&T)->U) -> Vec<Vec<
 
 /// Returns a hashmap from node id to number of places that node is used in the tree. Essentially this just
 /// follows all paths down from the root and logs how many times it encounters each node
-pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &EGraph) -> HashMap<Id,i32> {
+pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGraph) -> HashMap<Id,i32> {
     let mut num_paths_to_node: HashMap<Id,i32> = HashMap::new();
     treenodes.iter().for_each(|treenode| {
         num_paths_to_node.insert(*treenode, 0);
     });
-    fn helper(num_paths_to_node: &mut HashMap<Id,i32>, node: &Id, egraph: &EGraph) {
+    fn helper(num_paths_to_node: &mut HashMap<Id,i32>, node: &Id, egraph: &crate::EGraph) {
         // num_paths_to_node.insert(*child, num_paths_to_node[node] + 1);
         *num_paths_to_node.get_mut(node).unwrap() += 1;
         for child in egraph[*node].nodes[0].children() {


### PR DESCRIPTION
This is an alternate strategy discussed in #95 in which we decide what the index of an invention variable is on the spot instead of leaving that as a secondary inner search.

This PR seems to have the same results and about the same runtime (maybe even faster) compared to the original across a variety of domains including tower building ones.

This change is nice because it removed the most complicated part of the codebase (`assignments_of_pattern`) and also means that all the pruning happens in a single place rather than being replicated in many places