### PR TITLE
fixing the negative vars

### DIFF
--- a/data/basic/issue108.json
+++ b/data/basic/issue108.json
@@ -1,0 +1,3 @@
+[
+    "(lam (a (lam (lam (a (lam (lam (a (lam (lam ($5 b))) 0))) 0))) 0))"
+]

--- a/data/basic/issue108_2.json
+++ b/data/basic/issue108_2.json
@@ -1,0 +1,3 @@
+[
+    "(lam (logo_forLoop 6 (lam (lam (logo_FWRT (logo_MULL logo_UL $1) (logo_SUBA (logo_DIVA logo_UA 4) logo_UA) $0))) $0))"
+]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -993,7 +993,7 @@ impl FinishedPattern {
         let compressive_utility = compressive_utility(&pattern,shared);
         let noncompressive_utility = noncompressive_utility(pattern.body_utility, &shared.cfg);
         let utility = noncompressive_utility + compressive_utility.util;
-        assert!(utility <= pattern.utility_upper_bound);
+        assert!(utility <= pattern.utility_upper_bound, "{} BUT utility is higher: {}", pattern.info(&shared), utility);
         FinishedPattern {
             pattern,
             utility,
@@ -1115,10 +1115,18 @@ fn get_zippers(
                     });
                     // add new zid to this node
                     zids.push(*zid);
-                    // shift the arg but keep the unshifted part the sam
+                    // shift the arg but keep the unshifted part the same
                     let mut arg: Arg = arg_of_zid_node[*b_zid][&b].clone();
-                    arg.id = shift(arg.id, -1, egraph, cache).unwrap();
-                    arg.shift -= 1;
+                    if !egraph[arg.id].data.free_vars.is_empty() {
+                        // println!("stepping from child: {}", extract(b, egraph));
+                        // println!("stepping to parent : {}", extract(*treenode, egraph));
+                        // println!("b_zid: {}; b_zip: {:?}", b_zid, zip_of_zid[*b_zid]);
+                        // println!("shift from: {}", extract(arg.id, egraph));
+                        // println!("shift to:   {}", extract(arg.id, egraph));
+                        // println!("total shift: {}", arg.shift);
+                        arg.id = shift(arg.id, -1, egraph, cache).unwrap();
+                        arg.shift -= 1;
+                    }
                     arg_of_zid_node[*zid].insert(*treenode, arg);
                 }
                 let mut descendants: Vec<Id> = descendants_of_node[&b].clone();

--- a/src/extraction.rs
+++ b/src/extraction.rs
@@ -46,7 +46,7 @@ pub fn rewrite_fast(
     inv_name: &str,
 ) -> Vec<Expr>
 {
-    println!("rewriting with {}", pattern.info(&shared));
+    // println!("rewriting with {}", pattern.info(&shared));
     fn helper(
         pattern: &FinishedPattern,
         shared: &SharedData,


### PR DESCRIPTION
Fixing #108 

This is partway done. Ive actually fixed a few issues including
* we were discarding finished patterns with negatives vars before entirely when really we can just discard the specific locations within those patterns that have negative vars
* previously our `fast_rewrite` was not doing shifting right; you should always deep track of depth and only shift if things are pointers outside of the toplevel. that is now fixed

Still to do:
* Now we're hitting some serious shifting that gets like $-6 and I think either it is supposed to be like that and this is something we need to catch, or theres actually a mistake.
* Ill say im pretty sure inner abstractions wont cause any more shifting than initial outer ones even when they nest because the inner one can never  move you above a lambda that the outer one cant or something like that. So I think we might actually be totally sound in how we detect negative ivars meaning this is just a coding error right now thats creating the -6
* I think maybe instead of just resetting to depth 0 when you do an inner rewrite you should be also adjusting shift? or maybe not adjusting it but like somehow it needs to know that for the vars that point within the parent invention those ones dont need the same shifting stuff?
  * ya wait effectively you want to shift different ranges of free vars by different amounts. So perhaps you want a Vec<> of shift amounts and depth cutoffs or something?