### PR TITLE
migrate to AHash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.10.3"
 rand = "0.8.4"
 parking_lot = "0.12.0"
 colorful = "0.2.1"
+ahash = "0.7.6"
 
 [dependencies.pyo3]
 version = "0.16.1"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use std::collections::{HashMap, HashSet};
 use ahash::{AHasher, RandomState, AHashMap};
+
 use std::fmt::{self, Formatter, Display};
 use std::hash::Hash;
 use itertools::Itertools;
@@ -211,7 +212,7 @@ impl Expr {
 }
 
 /// returns the vec of zippers to each ivar
-fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &HashMap<Zip,ZId>) -> Vec<Vec<ZId>> {
+fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &AHashMap<Zip,ZId>) -> Vec<Vec<ZId>> {
 
     // quickly determine arity
     let mut arity = 0;
@@ -226,7 +227,7 @@ fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &HashMap<Zip,ZId>) -> Vec<Vec<Z
     let mut curr_zip: Zip = vec![];
     let mut zids_of_ivar = vec![vec![]; arity as usize];
 
-    fn helper(curr_node: Id, expr: &Expr, curr_zip: &mut Zip, zids_of_ivar: &mut Vec<Vec<ZId>>, zid_of_zip: &HashMap<Zip,ZId>) {
+    fn helper(curr_node: Id, expr: &Expr, curr_zip: &mut Zip, zids_of_ivar: &mut Vec<Vec<ZId>>, zid_of_zip: &AHashMap<Zip,ZId>) {
         match expr.get(curr_node) {
             Lambda::Prim(_) => {},
             Lambda::Var(_) => {},
@@ -497,21 +498,21 @@ pub struct CriticalMultithreadData {
 #[derive(Debug)]
 pub struct SharedData {
     pub crit: Mutex<CriticalMultithreadData>,
-    pub arg_of_zid_node: Vec<HashMap<Id,Arg>>,
+    pub arg_of_zid_node: Vec<AHashMap<Id,Arg>>,
     pub treenodes: Vec<Id>,
     pub programs_node: Id,
     pub roots: Vec<Id>,
-    pub zids_of_node: HashMap<Id,Vec<ZId>>,
+    pub zids_of_node: AHashMap<Id,Vec<ZId>>,
     pub zip_of_zid: Vec<Zip>,
-    pub zid_of_zip: HashMap<Zip, ZId>,
+    pub zid_of_zip: AHashMap<Zip, ZId>,
     pub extensions_of_zid: Vec<ZIdExtension>,
-    // pub refinables_of_shifted_arg: HashMap<Id,Vec<Id>>,
-    // pub uses_of_zid_refinable_loc: HashMap<(ZId,Id,Id),i32>,
-    pub uses_of_shifted_arg_refinement: HashMap<Id,HashMap<Id,usize>>,
+    // pub refinables_of_shifted_arg: AHashMap<Id,Vec<Id>>,
+    // pub uses_of_zid_refinable_loc: AHashMap<(ZId,Id,Id),i32>,
+    pub uses_of_shifted_arg_refinement: AHashMap<Id,AHashMap<Id,usize>>,
     pub egraph: EGraph,
     pub num_paths_to_node: AHashMap<Id,i32>,
-    pub tasks_of_node: HashMap<Id, HashSet<usize>>,
-    pub cost_of_node_once: HashMap<Id,i32>,
+    pub tasks_of_node: AHashMap<Id, HashSet<usize>>,
+    pub cost_of_node_once: AHashMap<Id,i32>,
     pub cost_of_node_all: AHashMap<Id,i32>,
     pub stats: Mutex<Stats>,
     pub cfg: CompressionStepConfig,
@@ -574,7 +575,7 @@ impl Invention {
     /// replace any #i with args[i], returning a new expression
     pub fn apply(&self, args: &[Expr]) -> Expr {
         assert_eq!(args.len(), self.arity);
-        let map: HashMap<i32, Expr> = args.iter().enumerate().map(|(i,e)| (i as i32, e.clone())).collect();
+        let map: AHashMap<i32, Expr> = args.iter().enumerate().map(|(i,e)| (i as i32, e.clone())).collect();
         ivar_replace(&self.body, self.body.root(), &map)
     }
 }
@@ -1163,7 +1164,7 @@ impl FinishedPattern {
 // }
 
 /// return all possible refinements you could use here along with counts for how many of each you can use
-fn get_refinements_of_shifted_id(shifted_id: Id, egraph: &crate::EGraph, cfg: &CompressionStepConfig) -> HashMap<Id,usize>
+fn get_refinements_of_shifted_id(shifted_id: Id, egraph: &crate::EGraph, cfg: &CompressionStepConfig) -> AHashMap<Id,usize>
 {
     fn helper(id: Id, egraph: &crate::EGraph, cfg: &CompressionStepConfig, refinements: &mut Vec<Id>) {
         let ivars =  egraph[id].data.free_ivars.len();
@@ -1186,7 +1187,7 @@ fn get_refinements_of_shifted_id(shifted_id: Id, egraph: &crate::EGraph, cfg: &C
     }
     let mut refinements = vec![];
     helper(shifted_id, egraph, cfg, &mut refinements);
-    refinements.into_iter().counts()
+    counts_ahash(&refinements)
 }
 
 /// figure out all the N^2 zippers from choosing any given node and then choosing a descendant and returning the zipper from
@@ -1194,27 +1195,27 @@ fn get_refinements_of_shifted_id(shifted_id: Id, egraph: &crate::EGraph, cfg: &C
 /// the descendant and introduced an invention rooted at the ancestor node.
 fn get_zippers(
     treenodes: &[Id],
-    cost_of_node_once: &HashMap<Id,i32>,
+    cost_of_node_once: &AHashMap<Id,i32>,
     no_cache: bool,
     egraph: &mut crate::EGraph,
     cfg: &CompressionStepConfig
-) -> (HashMap<Zip, ZId>, Vec<Zip>, Vec<HashMap<Id,Arg>>, HashMap<Id,Vec<ZId>>,  Vec<ZIdExtension>, HashMap<Id,HashMap<Id,usize>>) {
-    let cache: &mut Option<RecVarModCache> = &mut if no_cache { None } else { Some(HashMap::new()) };
+) -> (AHashMap<Zip, ZId>, Vec<Zip>, Vec<AHashMap<Id,Arg>>, AHashMap<Id,Vec<ZId>>,  Vec<ZIdExtension>, AHashMap<Id,AHashMap<Id,usize>>) {
+    let cache: &mut Option<RecVarModCache> = &mut if no_cache { None } else { Some(AHashMap::new()) };
 
-    let mut zid_of_zip: HashMap<Zip, ZId> = Default::default();
+    let mut zid_of_zip: AHashMap<Zip, ZId> = Default::default();
     let mut zip_of_zid: Vec<Zip> = Default::default();
-    let mut arg_of_zid_node: Vec<HashMap<Id,Arg>> = Default::default();
-    let mut zids_of_node: HashMap<Id,Vec<ZId>> = Default::default();
+    let mut arg_of_zid_node: Vec<AHashMap<Id,Arg>> = Default::default();
+    let mut zids_of_node: AHashMap<Id,Vec<ZId>> = Default::default();
 
 
-    // let mut refinements_of_shifted_arg: HashMap<Id,HashSet<Id>> = Default::default();
-    // let mut uses_of_zid_refinable_loc: HashMap<(ZId,Id,Id),i32> = Default::default();
-    let mut uses_of_shifted_arg_refinement: HashMap<Id,HashMap<Id,usize>> = Default::default();
+    // let mut refinements_of_shifted_arg: AHashMap<Id,HashSet<Id>> = Default::default();
+    // let mut uses_of_zid_refinable_loc: AHashMap<(ZId,Id,Id),i32> = Default::default();
+    let mut uses_of_shifted_arg_refinement: AHashMap<Id,AHashMap<Id,usize>> = Default::default();
 
 
     zid_of_zip.insert(vec![], EMPTY_ZID);
     zip_of_zid.push(vec![]);
-    arg_of_zid_node.push(HashMap::new());
+    arg_of_zid_node.push(AHashMap::new());
     assert!(EMPTY_ZID == 0);
     
     // loop over all nodes in all programs in bottom up order
@@ -1243,7 +1244,7 @@ fn get_zippers(
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip);
-                        arg_of_zid_node.push(HashMap::new());
+                        arg_of_zid_node.push(AHashMap::new());
                         zid
                     });
                     // add new zid to this node
@@ -1261,7 +1262,7 @@ fn get_zippers(
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip);
-                        arg_of_zid_node.push(HashMap::new());
+                        arg_of_zid_node.push(AHashMap::new());
                         zid
                     });
                     // add new zid to this node
@@ -1281,7 +1282,7 @@ fn get_zippers(
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip.clone());
-                        arg_of_zid_node.push(HashMap::new());
+                        arg_of_zid_node.push(AHashMap::new());
                         zid
                     });
                     // add new zid to this node
@@ -1604,7 +1605,7 @@ fn compressive_utility(pattern: &Pattern, shared: &SharedData) -> UtilityCalcula
 
     // the idea here is we want the fast-path to be the case where no conflicts happen. If no conflicts happen, there should be
     // zero heap allocations in this whole section! Since empty vecs and hashmaps dont cause allocations yet.
-    let mut corrected_utils: HashMap<Id,CorrectedUtil> = Default::default();
+    let mut corrected_utils: AHashMap<Id,CorrectedUtil> = Default::default();
     let mut global_correction = 0; // this is going to get added to the compressive_utility at the end to correct for use-conflicts
 
     // bottom up traversal since we assume match_locations is sorted
@@ -1738,7 +1739,7 @@ fn compressive_utility(pattern: &Pattern, shared: &SharedData) -> UtilityCalcula
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UtilityCalculation {
     pub util: i32,
-    pub corrected_utils: HashMap<Id,CorrectedUtil>,
+    pub corrected_utils: AHashMap<Id,CorrectedUtil>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1853,13 +1854,13 @@ pub fn compression_step(
     println!("num_paths_to_node(): {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
-    let tasks_of_node: HashMap<Id, HashSet<usize>> = associate_tasks(programs_node, &egraph, tasks);
+    let tasks_of_node: AHashMap<Id, HashSet<usize>> = associate_tasks(programs_node, &egraph, tasks);
 
     println!("associate_tasks(): {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
     // cost of a single usage of a node (same as inventionless_cost)
-    let cost_of_node_once: HashMap<Id,i32> = treenodes.iter().map(|node| (*node,egraph[*node].data.inventionless_cost)).collect();
+    let cost_of_node_once: AHashMap<Id,i32> = treenodes.iter().map(|node| (*node,egraph[*node].data.inventionless_cost)).collect();
     // cost of a single usage times number of paths to node
     let cost_of_node_all: AHashMap<Id,i32> = treenodes.iter().map(|node| (*node,cost_of_node_once[node] * num_paths_to_node[node])).collect();
 

--- a/src/egraphs.rs
+++ b/src/egraphs.rs
@@ -2,6 +2,8 @@ use itertools::Itertools;
 
 use crate::*;
 use std::collections::{HashMap, HashSet};
+use ahash::{AHasher, RandomState, AHashMap};
+
 
 pub type EGraph = egg::EGraph<Lambda, LambdaAnalysis>;
 
@@ -167,17 +169,17 @@ fn topological_ordering_rec(root: Id, egraph: &EGraph, vec: &mut Vec<Id>) {
     }
 }
 
-pub fn associate_tasks(programs_root: Id, egraph: &EGraph, tasks: &Vec<String>) -> HashMap<Id, HashSet<usize>> {
+pub fn associate_tasks(programs_root: Id, egraph: &EGraph, tasks: &Vec<String>) -> AHashMap<Id, HashSet<usize>> {
 
     // this is the map from egraph node ids to tasks (represented with unique usizes) that we will be building
-    let mut tasks_of_node = HashMap::new();
+    let mut tasks_of_node = AHashMap::new();
 
     let program_roots = egraph[programs_root].nodes[0].children();
     assert_eq!(program_roots.len(), tasks.len());
 
     // since the tasks may not be listed in any specific order, we need to keep track of whether we've already
     // made an id for a given task or not
-    let mut ids_of_tasks = HashMap::new();  // Keep track of the task -> task id mapping as we build the result
+    let mut ids_of_tasks = AHashMap::new();  // Keep track of the task -> task id mapping as we build the result
     let mut task_id: usize = 0;
     for (program_root, task) in program_roots.iter().zip(tasks) {
         if !ids_of_tasks.contains_key(task) {
@@ -193,7 +195,7 @@ pub fn associate_tasks(programs_root: Id, egraph: &EGraph, tasks: &Vec<String>) 
     tasks_of_node
 }
 
-fn associate_task_rec(node: Id, egraph: &EGraph, task_id: usize, tasks_of_node: &mut HashMap<Id, HashSet<usize>>) {
+fn associate_task_rec(node: Id, egraph: &EGraph, task_id: usize, tasks_of_node: &mut AHashMap<Id, HashSet<usize>>) {
     if !tasks_of_node.keys().contains(&node) {
         tasks_of_node.insert(node, HashSet::new());
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,8 @@ use crate::*;
 use sexp::{Sexp,Atom};
 use std::fmt::Debug;
 use std::collections::HashMap;
+use ahash::{AHasher, RandomState, AHashMap};
+
 
 /// Uncurries an s expression. For example: (app (app foo x) y) -> (foo x y)
 /// panics if sexp is already uncurried.
@@ -348,12 +350,12 @@ pub fn group_by_key<T: Copy, U: Ord>(v: Vec<T>, key: impl Fn(&T)->U) -> Vec<Vec<
 
 /// Returns a hashmap from node id to number of places that node is used in the tree. Essentially this just
 /// follows all paths down from the root and logs how many times it encounters each node
-pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGraph) -> HashMap<Id,i32> {
-    let mut num_paths_to_node: HashMap<Id,i32> = HashMap::new();
+pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGraph) -> AHashMap<Id,i32> {
+    let mut num_paths_to_node: AHashMap<Id,i32> = AHashMap::new();
     treenodes.iter().for_each(|treenode| {
         num_paths_to_node.insert(*treenode, 0);
     });
-    fn helper(num_paths_to_node: &mut HashMap<Id,i32>, node: &Id, egraph: &crate::EGraph) {
+    fn helper(num_paths_to_node: &mut AHashMap<Id,i32>, node: &Id, egraph: &crate::EGraph) {
         // num_paths_to_node.insert(*child, num_paths_to_node[node] + 1);
         *num_paths_to_node.get_mut(node).unwrap() += 1;
         for child in egraph[*node].nodes[0].children() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,6 +3,7 @@ use sexp::{Sexp,Atom};
 use std::fmt::Debug;
 use std::collections::HashMap;
 use ahash::{AHasher, RandomState, AHashMap};
+use std::hash::Hash;
 
 
 /// Uncurries an s expression. For example: (app (app foo x) y) -> (foo x y)
@@ -147,7 +148,7 @@ pub fn compression_factor(original: &Expr, compressed: &Expr) -> f64 {
 }
 
 /// Replace the ivars in an expr based on an i32->Expr map
-pub fn ivar_replace(e: &Expr, child: Id, map: &HashMap<i32, Expr>) -> Expr {
+pub fn ivar_replace(e: &Expr, child: Id, map: &AHashMap<i32, Expr>) -> Expr {
     match e.get(child) {
         Lambda::IVar(i) => map.get(&i).unwrap_or(&e).clone(),
         Lambda::Var(v) => Expr::var(*v),
@@ -206,7 +207,7 @@ pub fn replace_prim_with(s: &str, prim: &str, new: &str) -> String {
 }
 
 /// cache for shift()
-pub type RecVarModCache = HashMap<(Id,i32),Option<Id>>;
+pub type RecVarModCache = AHashMap<(Id,i32),Option<Id>>;
 
 
 /// This is a helper function for implementing various recursive operations that only
@@ -368,3 +369,24 @@ pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGra
     num_paths_to_node
 }
 
+/// same as Itertools::counts() but returns an AHashMap instead of a HashMap
+pub fn counts_ahash<T: Hash + Eq + Clone>(v: &Vec<T>) -> AHashMap<T, usize>
+{
+    let mut counts = AHashMap::new();
+    v.iter().for_each(|item| *counts.entry(item.clone()).or_default() += 1);
+    counts
+}
+
+
+// pub trait IterUtil : Iterator {
+//     /// same as Itertools::counts() but returns an AHashMap instead of a HashMap
+//     fn counts_ahash(self) -> AHashMap<Self::Item, usize>
+//     where
+//         Self: Sized,
+//         Self::Item: Eq + Hash,
+//     {
+//         let mut counts = AHashMap::new();
+//         self.for_each(|item| *counts.entry(item).or_default() += 1);
+//         counts
+//     }
+// }


### PR DESCRIPTION
Just a faster hash function. The default one is cryptographic and we dont need that hence the ahash migration.

1.35x speedup on `data/cogsci/house.json -i1`
1.5x speedup on `data/cogsci/nuts-bolts -a4` 
probably faster on everything else too