### PR TITLE
Handle existing DC inventions in programs to be compressed and rewritten.

### DIFF
--- a/src/bin/rewrite.rs
+++ b/src/bin/rewrite.rs
@@ -68,12 +68,6 @@ fn main() {
             .expect("json deserializing error");
     let inventions = inventions_data["invs"].as_array().unwrap();
 
-    // Get any prior inventions from the existing DSL.
-    let mut input = args
-        .fmt
-        .load_programs_and_tasks(&args.program_file)
-        .unwrap();
-
     let dreamcoder_translation: Vec<(String, String)> = inventions
         .iter()
         .map(|invention| {
@@ -94,43 +88,15 @@ fn main() {
         .collect();
     println!("Number of inventions: {}", inventions.len());
 
-    // Read in the programs. Maintain the DC format if we're using it.
-    let mut programs: Vec<String> = Vec::new();
-    let mut program_id_to_task_name: HashMap<usize, String> = HashMap::new();
+    // Read in the programs and any previous inventions from the DSL.
+    let mut input = args
+        .fmt
+        .load_programs_and_tasks(&args.program_file)
+        .unwrap();
+
     let mut rewritten_frontiers: HashMap<String, Vec<String>> = HashMap::new();
-    match args.fmt {
-        InputFormat::Dreamcoder => {
-            // Read in frontiers to programs, but preserve their original task.
-            let json: serde_json::Value =
-                from_reader(File::open(&args.program_file).expect("file not found"))
-                    .expect("json deserializing error");
 
-            let frontiers = json["frontiers"].as_array().unwrap();
-            println!("Read in {} frontiers", frontiers.len());
-            let mut program_id = 0;
-            for frontier in frontiers.into_iter() {
-                let task_name = frontier["task"].as_str().unwrap().to_string();
-                for dc_program in frontier["programs"].as_array().unwrap() {
-                    let stitch_program = dc_program["program"]
-                        .as_str()
-                        .unwrap()
-                        .to_string()
-                        .replace("(lambda ", "(lam ");
-                    program_id_to_task_name.insert(program_id, task_name.clone());
-                    program_id += 1;
-                    programs.push(stitch_program);
-                }
-            }
-            println!("Read in {} programs from these frontiers", programs.len());
-        }
-        InputFormat::ProgramsList => {
-            // Read in programs to rewrite.
-            programs = from_reader(File::open(&args.program_file).expect("file not found"))
-                .expect("json deserializing error");
-        }
-    }
-
-    let programs: Vec<Expr> = programs.iter().map(|p| p.parse().unwrap()).collect();
+    let programs: Vec<Expr> = input.programs.iter().map(|p| p.parse().unwrap()).collect();
     programs_info(&programs);
 
     let programs: Expr = Expr::programs(programs);
@@ -151,7 +117,7 @@ fn main() {
 
             // Rewrite back the lambda and optionally rewrite back the DC invention format.
             for (i, pretty_program) in rewritten.split_programs().iter().enumerate() {
-                let task_name = program_id_to_task_name[&i].clone();
+                let task_name = input.tasks[i].clone();
                 let mut pretty_program = pretty_program.to_string();
                 if args.dreamcoder_output {
                     // Rewrite using any existing inventions.

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,34 +1,34 @@
 use crate::*;
 use ahash::{AHashMap, AHashSet};
 // use std::collections::BTreeSet;
-use std::fmt::{self, Formatter, Display};
-use std::hash::Hash;
-use itertools::Itertools;
+use clap::Parser;
 use extraction::extract;
-use serde_json::json;
-use clap::{Parser};
-use serde::Serialize;
-use std::thread;
-use std::sync::Arc;
+use itertools::Itertools;
 use parking_lot::Mutex;
-use std::ops::DerefMut;
-use std::collections::BinaryHeap;
 use rand::Rng;
+use serde::Serialize;
+use serde_json::json;
+use std::collections::BinaryHeap;
+use std::fmt::{self, Display, Formatter};
+use std::hash::Hash;
+use std::ops::DerefMut;
+use std::sync::Arc;
+use std::thread;
 
 /// Args for compression step
 #[derive(Parser, Debug, Serialize, Clone)]
 #[clap(name = "Stitch")]
 pub struct CompressionStepConfig {
     /// max arity of inventions to find (will find all from 0 to this number inclusive)
-    #[clap(short='a', long, default_value = "2")]
+    #[clap(short = 'a', long, default_value = "2")]
     pub max_arity: usize,
 
     /// num threads (no parallelism if set to 1)
-    #[clap(short='t', long, default_value = "1")]
+    #[clap(short = 't', long, default_value = "1")]
     pub threads: usize,
 
     /// how many worklist items a thread will take at once
-    #[clap(short='b', long, default_value = "1")]
+    #[clap(short = 'b', long, default_value = "1")]
     pub batch: usize,
 
     /// threads will autoadjust how large their batches are based on the worklist size
@@ -48,7 +48,7 @@ pub struct CompressionStepConfig {
     pub max_refinement_arity: usize,
 
     /// Number of invention candidates compression_step should return. Raising this may weaken the efficacy of upper bound pruning
-    #[clap(short='n', long, default_value = "1")]
+    #[clap(short = 'n', long, default_value = "1")]
     pub inv_candidates: usize,
 
     /// pattern or invention to track
@@ -100,7 +100,7 @@ pub struct CompressionStepConfig {
     pub no_cache: bool,
 
     /// print out programs rewritten under invention
-    #[clap(long,short='r')]
+    #[clap(long, short = 'r')]
     pub show_rewritten: bool,
 
     /// disable the free variable pruning optimization
@@ -148,7 +148,6 @@ pub struct CompressionStepConfig {
     /// anything related to running a dreamcoder comparison
     #[clap(long)]
     pub dreamcoder_comparison: bool,
-    
 }
 
 impl CompressionStepConfig {
@@ -162,28 +161,26 @@ impl CompressionStepConfig {
     }
 }
 
-
-
 /// A Pattern is a partial invention with holes. The simplest pattern is the single hole `??` which
 /// matches at all nodes in the program set. From this single hole in a top-down manner we grow more complex
 /// patterns like `(+ ?? ??)` and `(+ 3 (* ?? ??))`. Expanding a hole in a pattern always results in a pattern
 /// that matches at a subset of the places that the original pattern matched.
-/// 
+///
 /// `match_locations` is the list of structurally hashed nodes where the pattern matches.
 /// `holes` is the list of zippers that point from the root of the pattern to the holes.
 /// `arg_choices` is the same as `holes` but for the invention arguments like #i
 /// `body_utility` is the cost of the non-hole non-argchoice parts of the pattern so far
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Pattern {
-    pub holes: Vec<ZId>, // in order of when theyre added NOT left to right
+    pub holes: Vec<ZId>,           // in order of when theyre added NOT left to right
     arg_choices: Vec<LabelledZId>, // a hole gets moved into here when it becomes an argchoice, again these are in order of when they were added
     pub first_zid_of_ivar: Vec<ZId>, //first_zid_of_ivar[i] gives the index of the first use of #i in arg_choices
     pub refinements: Vec<Option<Vec<Id>>>, // refinements[i] gives the list of refinements for #i
-    pub match_locations: Vec<Id>, // places where it applies
+    pub match_locations: Vec<Id>,    // places where it applies
     pub utility_upper_bound: i32,
     pub body_utility_no_refinement: i32, // the size (in `cost`) of a single use of the pattern body so far
     pub refinement_body_utility: i32, // modifier on body_utility to include the full size account for refinement
-    pub tracked: bool, // for debugging
+    pub tracked: bool,                // for debugging
 }
 
 impl Expr {
@@ -201,9 +198,9 @@ impl Expr {
         for znode in zip.iter() {
             child = match (znode, self.get(child)) {
                 (ZNode::Body, Lambda::Lam([b])) => *b,
-                (ZNode::Func, Lambda::App([f,_])) => *f,
-                (ZNode::Arg, Lambda::App([_,x])) => *x,
-                (_,_) => return None // no zipper works here
+                (ZNode::Func, Lambda::App([f, _])) => *f,
+                (ZNode::Arg, Lambda::App([_, x])) => *x,
+                (_, _) => return None, // no zipper works here
             };
         }
         Some(child)
@@ -211,8 +208,7 @@ impl Expr {
 }
 
 /// returns the vec of zippers to each ivar
-fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &AHashMap<Zip,ZId>) -> Vec<Vec<ZId>> {
-
+fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &AHashMap<Zip, ZId>) -> Vec<Vec<ZId>> {
     // quickly determine arity
     let mut arity = 0;
     for node in expr.nodes.iter() {
@@ -226,19 +222,25 @@ fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &AHashMap<Zip,ZId>) -> Vec<Vec<
     let mut curr_zip: Zip = vec![];
     let mut zids_of_ivar = vec![vec![]; arity as usize];
 
-    fn helper(curr_node: Id, expr: &Expr, curr_zip: &mut Zip, zids_of_ivar: &mut Vec<Vec<ZId>>, zid_of_zip: &AHashMap<Zip,ZId>) {
+    fn helper(
+        curr_node: Id,
+        expr: &Expr,
+        curr_zip: &mut Zip,
+        zids_of_ivar: &mut Vec<Vec<ZId>>,
+        zid_of_zip: &AHashMap<Zip, ZId>,
+    ) {
         match expr.get(curr_node) {
-            Lambda::Prim(_) => {},
-            Lambda::Var(_) => {},
+            Lambda::Prim(_) => {}
+            Lambda::Var(_) => {}
             Lambda::IVar(i) => {
                 zids_of_ivar[*i as usize].push(zid_of_zip[curr_zip]);
-            },
+            }
             Lambda::Lam([b]) => {
                 curr_zip.push(ZNode::Body);
                 helper(*b, expr, curr_zip, zids_of_ivar, zid_of_zip);
                 curr_zip.pop();
             }
-            Lambda::App([f,x]) => {
+            Lambda::App([f, x]) => {
                 curr_zip.push(ZNode::Func);
                 helper(*f, expr, curr_zip, zids_of_ivar, zid_of_zip);
                 curr_zip.pop();
@@ -248,27 +250,44 @@ fn zids_of_ivar_of_expr(expr: &Expr, zid_of_zip: &AHashMap<Zip,ZId>) -> Vec<Vec<
             }
             _ => unreachable!(),
         }
-        
     }
     // we can pick any match location
-    helper(expr.root(), expr, &mut curr_zip, &mut zids_of_ivar, zid_of_zip);
+    helper(
+        expr.root(),
+        expr,
+        &mut curr_zip,
+        &mut zids_of_ivar,
+        zid_of_zip,
+    );
 
     zids_of_ivar
 }
 
-
 impl Pattern {
     /// create a single hole pattern `??`
     #[inline(never)]
-    fn single_hole(treenodes: &Vec<Id>, cost_of_node_all: &Vec<i32>, num_paths_to_node: &Vec<i32>, egraph: &crate::EGraph, cfg: &CompressionStepConfig) -> Self {
+    fn single_hole(
+        treenodes: &Vec<Id>,
+        cost_of_node_all: &Vec<i32>,
+        num_paths_to_node: &Vec<i32>,
+        egraph: &crate::EGraph,
+        cfg: &CompressionStepConfig,
+    ) -> Self {
         let body_utility_no_refinement = 0;
         let refinement_body_utility = 0;
         let mut match_locations = treenodes.clone();
         match_locations.sort(); // we assume match_locations is always sorted
         if cfg.no_top_lambda {
-            match_locations.retain(|node| expands_to_of_node(&egraph[*node].nodes[0]) != ExpandsTo::Lam);
+            match_locations
+                .retain(|node| expands_to_of_node(&egraph[*node].nodes[0]) != ExpandsTo::Lam);
         }
-        let utility_upper_bound = utility_upper_bound(&match_locations, body_utility_no_refinement + refinement_body_utility, cost_of_node_all, num_paths_to_node, cfg);
+        let utility_upper_bound = utility_upper_bound(
+            &match_locations,
+            body_utility_no_refinement + refinement_body_utility,
+            cost_of_node_all,
+            num_paths_to_node,
+            cfg,
+        );
         Pattern {
             holes: vec![EMPTY_ZID], // (zid 0 is the empty zipper)
             arg_choices: vec![],
@@ -277,7 +296,7 @@ impl Pattern {
             match_locations, // single hole matches everywhere
             utility_upper_bound,
             body_utility_no_refinement, // 0 body utility
-            refinement_body_utility, // 0 body utility
+            refinement_body_utility,    // 0 body utility
             tracked: cfg.track.is_some(),
         }
     }
@@ -285,60 +304,81 @@ impl Pattern {
     fn to_expr(&self, shared: &SharedData) -> Expr {
         let mut curr_zip: Zip = vec![];
         // map zids to zips with a bool thats true if this is a hole and false if its a future ivar
-        let zips: Vec<(Zip,Expr)> = self.holes.iter().map(|zid| (shared.zip_of_zid[*zid].clone(), Expr::prim("??".into())))
-            .chain(self.arg_choices.iter().map(|labelled_zid| (shared.zip_of_zid[labelled_zid.zid].clone(),
-                if let Some(refinements) = self.refinements[labelled_zid.ivar].as_ref() {
+        let zips: Vec<(Zip, Expr)> = self
+            .holes
+            .iter()
+            .map(|zid| (shared.zip_of_zid[*zid].clone(), Expr::prim("??".into())))
+            .chain(self.arg_choices.iter().map(|labelled_zid| {
+                (
+                    shared.zip_of_zid[labelled_zid.zid].clone(),
+                    if let Some(refinements) = self.refinements[labelled_zid.ivar].as_ref() {
+                        // extract the refinement and remap #i to $(i+depth) where depth is depth of #i in `extracted`
+                        let mut extracted = refinements
+                            .iter()
+                            .map(|refinement| extract(*refinement, &shared.egraph))
+                            .collect::<Vec<_>>();
+                        extracted.iter_mut().for_each(|e| arg_ivars_to_vars(e));
+                        let mut expr = Expr::ivar(labelled_zid.ivar as i32);
+                        // todo are these applied in the right order?
+                        for e in extracted {
+                            expr = Expr::app(expr, e);
+                        }
+                        expr
+                    } else {
+                        Expr::ivar(labelled_zid.ivar as i32)
+                    },
+                )
+            }))
+            .collect();
 
-                    // extract the refinement and remap #i to $(i+depth) where depth is depth of #i in `extracted`
-                    let mut extracted = refinements.iter().map(|refinement| extract(*refinement, &shared.egraph)).collect::<Vec<_>>();
-                    extracted.iter_mut().for_each(|e| arg_ivars_to_vars(e));
-                    let mut expr = Expr::ivar(labelled_zid.ivar as i32);
-                    // todo are these applied in the right order?
-                    for e in extracted {
-                        expr = Expr::app(expr,e);
-                    }
-                    expr
-                } else {
-                    Expr::ivar(labelled_zid.ivar as i32)
-                }))).collect();
-
-
-        fn helper(curr_node: Id, curr_zip: &mut Zip, zips: &Vec<(Zip,Expr)>, shared: &SharedData) -> Expr {
-            match zips.iter().find(|(zip,_)| zip == curr_zip) {
+        fn helper(
+            curr_node: Id,
+            curr_zip: &mut Zip,
+            zips: &Vec<(Zip, Expr)>,
+            shared: &SharedData,
+        ) -> Expr {
+            match zips.iter().find(|(zip, _)| zip == curr_zip) {
                 // current zip matches a hole
-                Some((_,e)) => e.clone(),
+                Some((_, e)) => e.clone(),
                 // no ivar zip match, so recurse
-                None => {
-                    match &shared.node_of_id[usize::from(curr_node)] {
-                        Lambda::Prim(p) => Expr::prim(*p),
-                        Lambda::Var(v) => Expr::var(*v),
-                        Lambda::Lam([b]) => {
-                            curr_zip.push(ZNode::Body);
-                            let b_expr = helper(*b, curr_zip, &zips, shared);
-                            curr_zip.pop();
-                            Expr::lam(b_expr) 
-                        }
-                        Lambda::App([f,x]) => {
-                            curr_zip.push(ZNode::Func);
-                            let f_expr = helper(*f, curr_zip, &zips, shared);
-                            curr_zip.pop();
-                            curr_zip.push(ZNode::Arg);
-                            let x_expr = helper(*x, curr_zip, &zips, shared);
-                            curr_zip.pop();
-                            Expr::app(f_expr, x_expr)
-                        }
-                        _ => unreachable!(),
+                None => match &shared.node_of_id[usize::from(curr_node)] {
+                    Lambda::Prim(p) => Expr::prim(*p),
+                    Lambda::Var(v) => Expr::var(*v),
+                    Lambda::Lam([b]) => {
+                        curr_zip.push(ZNode::Body);
+                        let b_expr = helper(*b, curr_zip, &zips, shared);
+                        curr_zip.pop();
+                        Expr::lam(b_expr)
                     }
-                }
+                    Lambda::App([f, x]) => {
+                        curr_zip.push(ZNode::Func);
+                        let f_expr = helper(*f, curr_zip, &zips, shared);
+                        curr_zip.pop();
+                        curr_zip.push(ZNode::Arg);
+                        let x_expr = helper(*x, curr_zip, &zips, shared);
+                        curr_zip.pop();
+                        Expr::app(f_expr, x_expr)
+                    }
+                    _ => unreachable!(),
+                },
             }
-            
         }
         // we can pick any match location
         helper(self.match_locations[0], &mut curr_zip, &zips, shared)
     }
     fn show_track_expansion(&self, hole_zid: ZId, shared: &SharedData) -> String {
-        let mut s = self.to_expr(shared).zipper_replace(&shared.zip_of_zid[hole_zid], &"<REPLACE>" ).to_string();
-        s = s.replace(&"<REPLACE>", &format!("{}",tracked_expands_to(self, hole_zid, shared)).clone().magenta().bold().to_string());
+        let mut s = self
+            .to_expr(shared)
+            .zipper_replace(&shared.zip_of_zid[hole_zid], &"<REPLACE>")
+            .to_string();
+        s = s.replace(
+            &"<REPLACE>",
+            &format!("{}", tracked_expands_to(self, hole_zid, shared))
+                .clone()
+                .magenta()
+                .bold()
+                .to_string(),
+        );
         s
     }
     pub fn info(&self, shared: &SharedData) -> String {
@@ -373,7 +413,7 @@ impl ExpandsTo {
     fn is_ivar(&self) -> bool {
         match self {
             ExpandsTo::IVar(_) => true,
-            _ => false
+            _ => false,
         }
     }
 }
@@ -418,11 +458,11 @@ fn expands_to_of_node(node: &Lambda) -> ExpandsTo {
             } else {
                 ExpandsTo::Prim(*p)
             }
-        },
+        }
         Lambda::Lam(_) => ExpandsTo::Lam,
         Lambda::App(_) => ExpandsTo::App,
         Lambda::IVar(i) => ExpandsTo::IVar(*i),
-        _ => unreachable!()
+        _ => unreachable!(),
     }
 }
 
@@ -431,8 +471,13 @@ fn expands_to_of_node(node: &Lambda) -> ExpandsTo {
 fn tracked_expands_to(pattern: &Pattern, hole_zid: ZId, shared: &SharedData) -> ExpandsTo {
     // apply the hole zipper to the original expr being tracked to get the subtree
     // this will expand into, then get the ExpandsTo of that
-    let id = shared.tracking.as_ref().unwrap().expr
-        .apply_zipper(&shared.zip_of_zid[hole_zid]).unwrap();
+    let id = shared
+        .tracking
+        .as_ref()
+        .unwrap()
+        .expr
+        .apply_zipper(&shared.zip_of_zid[hole_zid])
+        .unwrap();
     match expands_to_of_node(shared.tracking.as_ref().unwrap().expr.get(id)) {
         ExpandsTo::IVar(i) => {
             // in the case where we're searching for an IVar we need to be robust to relabellings
@@ -442,7 +487,7 @@ fn tracked_expands_to(pattern: &Pattern, hole_zid: ZId, shared: &SharedData) -> 
             // must correspond to each other in the pattern and the tracked expr and we can just return
             // the pattern version (`j` below).
             let zids = shared.tracking.as_ref().unwrap().zids_of_ivar[i as usize].clone();
-            for (j,zid) in pattern.first_zid_of_ivar.iter().enumerate() {
+            for (j, zid) in pattern.first_zid_of_ivar.iter().enumerate() {
                 if zids.contains(zid) {
                     return ExpandsTo::IVar(j as i32);
                 }
@@ -450,12 +495,12 @@ fn tracked_expands_to(pattern: &Pattern, hole_zid: ZId, shared: &SharedData) -> 
             // it's a new ivar that hasnt been used already so it must take on the next largest var number
             return ExpandsTo::IVar(pattern.first_zid_of_ivar.len() as i32);
         }
-        e => e
+        e => e,
     }
 }
 
 /// The heap item used for heap-based worklists. Holds a pattern
-#[derive(Debug,Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct HeapItem {
     key: i32,
     pattern: Pattern,
@@ -477,11 +522,10 @@ impl HeapItem {
             key: pattern.utility_upper_bound,
             // system time is suuuper slow btw you want to do something else
             // key: std::time::SystemTime::now().duration_since(std::time::SystemTime::UNIX_EPOCH).unwrap().as_nanos() as i32,
-            pattern
+            pattern,
         }
     }
 }
-
 
 /// This is the multithread data locked during the critical section of the algorithm.
 #[derive(Debug, Clone)]
@@ -497,18 +541,18 @@ pub struct CriticalMultithreadData {
 #[derive(Debug)]
 pub struct SharedData {
     pub crit: Mutex<CriticalMultithreadData>,
-    pub arg_of_zid_node: Vec<AHashMap<Id,Arg>>,
+    pub arg_of_zid_node: Vec<AHashMap<Id, Arg>>,
     pub treenodes: Vec<Id>,
     pub node_of_id: Vec<Lambda>,
     pub programs_node: Id,
     pub roots: Vec<Id>,
-    pub zids_of_node: AHashMap<Id,Vec<ZId>>,
+    pub zids_of_node: AHashMap<Id, Vec<ZId>>,
     pub zip_of_zid: Vec<Zip>,
     pub zid_of_zip: AHashMap<Zip, ZId>,
     pub extensions_of_zid: Vec<ZIdExtension>,
     // pub refinables_of_shifted_arg: AHashMap<Id,Vec<Id>>,
     // pub uses_of_zid_refinable_loc: AHashMap<(ZId,Id,Id),i32>,
-    pub uses_of_shifted_arg_refinement: AHashMap<Id,AHashMap<Id,usize>>,
+    pub uses_of_shifted_arg_refinement: AHashMap<Id, AHashMap<Id, usize>>,
     pub egraph: EGraph,
     pub num_paths_to_node: Vec<i32>,
     pub tasks_of_node: Vec<AHashSet<usize>>,
@@ -532,11 +576,23 @@ pub struct Tracking {
 impl CriticalMultithreadData {
     /// Create a new mutable multithread data struct with
     /// a worklist that just has a single hole on it
-    fn new(donelist: Vec<FinishedPattern>, treenodes: &Vec<Id>, cost_of_node_all: &Vec<i32>, num_paths_to_node: &Vec<i32>, egraph: &crate::EGraph, cfg: &CompressionStepConfig) -> Self {
+    fn new(
+        donelist: Vec<FinishedPattern>,
+        treenodes: &Vec<Id>,
+        cost_of_node_all: &Vec<i32>,
+        num_paths_to_node: &Vec<i32>,
+        egraph: &crate::EGraph,
+        cfg: &CompressionStepConfig,
+    ) -> Self {
         // push an empty hole onto a new worklist
         let mut worklist = BinaryHeap::new();
-        worklist.push(HeapItem::new(Pattern::single_hole(treenodes, cost_of_node_all, num_paths_to_node, egraph, cfg)));
-        
+        worklist.push(HeapItem::new(Pattern::single_hole(
+            treenodes,
+            cost_of_node_all,
+            num_paths_to_node,
+            egraph,
+            cfg,
+        )));
         let mut res = CriticalMultithreadData {
             donelist,
             worklist,
@@ -546,20 +602,24 @@ impl CriticalMultithreadData {
         res.update(cfg);
         res
     }
-    /// sort the donelist by utility, truncate to cfg.inv_candidates, update 
+    /// sort the donelist by utility, truncate to cfg.inv_candidates, update
     /// update utility_pruning_cutoff to be the lowest utility
     #[inline(never)]
     fn update(&mut self, cfg: &CompressionStepConfig) {
         // sort in decreasing order by utility primarily, and break ties using the argchoice zids (just in order to be deterministic!)
         // let old_best = self.donelist.first().map(|x|x.utility).unwrap_or(0);
-        self.donelist.sort_unstable_by(|a,b| (b.utility,&b.pattern.arg_choices).cmp(&(a.utility,&a.pattern.arg_choices)));
+        self.donelist.sort_unstable_by(|a, b| {
+            (b.utility, &b.pattern.arg_choices).cmp(&(a.utility, &a.pattern.arg_choices))
+        });
         self.donelist.truncate(cfg.inv_candidates);
         // the cutoff is the lowest utility
-        self.utility_pruning_cutoff = if cfg.no_opt_upper_bound { 0 } else { std::cmp::max(0,self.donelist.last().map(|x|x.utility).unwrap_or(0)) };
+        self.utility_pruning_cutoff = if cfg.no_opt_upper_bound {
+            0
+        } else {
+            std::cmp::max(0, self.donelist.last().map(|x| x.utility).unwrap_or(0))
+        };
     }
 }
-
-
 
 /// At the end of the day we convert our Inventions into InventionExprs to make
 /// them standalone without needing to carry the EGraph around to figure out what
@@ -572,12 +632,20 @@ pub struct Invention {
 }
 impl Invention {
     pub fn new(body: Expr, arity: usize, name: &str) -> Self {
-        Self { body, arity, name: String::from(name) }
+        Self {
+            body,
+            arity,
+            name: String::from(name),
+        }
     }
     /// replace any #i with args[i], returning a new expression
     pub fn apply(&self, args: &[Expr]) -> Expr {
         assert_eq!(args.len(), self.arity);
-        let map: AHashMap<i32, Expr> = args.iter().enumerate().map(|(i,e)| (i as i32, e.clone())).collect();
+        let map: AHashMap<i32, Expr> = args
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (i as i32, e.clone()))
+            .collect();
         ivar_replace(&self.body, self.body.root(), &map)
     }
 }
@@ -594,7 +662,7 @@ impl Display for Invention {
 pub enum ZNode {
     // * order of variants here is important because the derived Ord will use it
     Func, // zipper went into the function, so Id is the arg
-    Body, 
+    Body,
     Arg, // zipper went into the arg, so Id is the function
 }
 
@@ -602,14 +670,14 @@ pub enum ZNode {
 pub type ZId = usize;
 
 /// a zid referencing a specific ZPath and a #i index
-#[derive(Debug,Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
 struct LabelledZId {
     zid: ZId,
-    ivar: usize // which #i argument this is, which also corresponds to args[i] ofc
+    ivar: usize, // which #i argument this is, which also corresponds to args[i] ofc
 }
 
 /// Various tracking stats
-#[derive(Clone,Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct Stats {
     worklist_steps: usize,
     finished: usize,
@@ -651,43 +719,110 @@ impl HoleChoice {
             &HoleChoice::Random => {
                 let mut rng = rand::thread_rng();
                 rng.gen_range(0..pattern.holes.len())
-            },
+            }
             &HoleChoice::FewApps => {
-                pattern.holes.iter().enumerate().map(|(hole_idx,hole_zid)|
-                    (hole_idx, pattern.match_locations.iter().filter(|loc|shared.arg_of_zid_node[*hole_zid][loc].expands_to == ExpandsTo::App).count()))
-                        .min_by_key(|x|x.1).unwrap().0
+                pattern
+                    .holes
+                    .iter()
+                    .enumerate()
+                    .map(|(hole_idx, hole_zid)| {
+                        (
+                            hole_idx,
+                            pattern
+                                .match_locations
+                                .iter()
+                                .filter(|loc| {
+                                    shared.arg_of_zid_node[*hole_zid][loc].expands_to
+                                        == ExpandsTo::App
+                                })
+                                .count(),
+                        )
+                    })
+                    .min_by_key(|x| x.1)
+                    .unwrap()
+                    .0
             }
             &HoleChoice::MaxCost => {
-                pattern.holes.iter().enumerate().map(|(hole_idx,hole_zid)|
-                    (hole_idx, pattern.match_locations.iter().map(|loc|shared.arg_of_zid_node[*hole_zid][loc].cost).sum::<i32>()))
-                        .max_by_key(|x|x.1).unwrap().0
+                pattern
+                    .holes
+                    .iter()
+                    .enumerate()
+                    .map(|(hole_idx, hole_zid)| {
+                        (
+                            hole_idx,
+                            pattern
+                                .match_locations
+                                .iter()
+                                .map(|loc| shared.arg_of_zid_node[*hole_zid][loc].cost)
+                                .sum::<i32>(),
+                        )
+                    })
+                    .max_by_key(|x| x.1)
+                    .unwrap()
+                    .0
             }
             &HoleChoice::MinCost => {
-                pattern.holes.iter().enumerate().map(|(hole_idx,hole_zid)|
-                    (hole_idx, pattern.match_locations.iter().map(|loc|shared.arg_of_zid_node[*hole_zid][loc].cost).sum::<i32>()))
-                        .min_by_key(|x|x.1).unwrap().0
+                pattern
+                    .holes
+                    .iter()
+                    .enumerate()
+                    .map(|(hole_idx, hole_zid)| {
+                        (
+                            hole_idx,
+                            pattern
+                                .match_locations
+                                .iter()
+                                .map(|loc| shared.arg_of_zid_node[*hole_zid][loc].cost)
+                                .sum::<i32>(),
+                        )
+                    })
+                    .min_by_key(|x| x.1)
+                    .unwrap()
+                    .0
             }
             &HoleChoice::MaxLargestSubset => {
                 // todo warning this is extremely slow, partially bc of counts() but I think
                 // mainly because where there are like dozens of holes doing all these lookups and clones and hashmaps is a LOT
-                pattern.holes.iter().enumerate()
-                    .map(|(hole_idx,hole_zid)| (hole_idx, *pattern.match_locations.iter()
-                        .map(|loc| shared.arg_of_zid_node[*hole_zid][loc].expands_to.clone()).counts().values().max().unwrap())).max_by_key(|&(_,max_count)| max_count).unwrap().0
+                pattern
+                    .holes
+                    .iter()
+                    .enumerate()
+                    .map(|(hole_idx, hole_zid)| {
+                        (
+                            hole_idx,
+                            *pattern
+                                .match_locations
+                                .iter()
+                                .map(|loc| {
+                                    shared.arg_of_zid_node[*hole_zid][loc].expands_to.clone()
+                                })
+                                .counts()
+                                .values()
+                                .max()
+                                .unwrap(),
+                        )
+                    })
+                    .max_by_key(|&(_, max_count)| max_count)
+                    .unwrap()
+                    .0
             }
-            _ => unimplemented!()
+            _ => unimplemented!(),
         }
     }
 }
 
 impl LabelledZId {
     fn new(zid: ZId, ivar: usize) -> LabelledZId {
-        LabelledZId { zid: zid, ivar: ivar }
+        LabelledZId {
+            zid: zid,
+            ivar: ivar,
+        }
     }
 }
 
 /// tells you which zid if any you would get if you extended the depth
 /// (of whatever the current zid is) with any of these znodes.
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct ZIdExtension {
     body: Option<ZId>,
     arg: Option<ZId>,
@@ -701,23 +836,36 @@ fn get_worklist_item(
     worklist_buf: &mut Vec<HeapItem>,
     donelist_buf: &mut Vec<FinishedPattern>,
     shared: &Arc<SharedData>,
-) -> Option<(Vec<Pattern>,i32)> {
-
+) -> Option<(Vec<Pattern>, i32)> {
     // * MULTITHREADING: CRITICAL SECTION START *
     // take the lock, which will be released immediately when this scope exits
     let mut shared_guard = shared.crit.lock();
     let mut crit: &mut CriticalMultithreadData = shared_guard.deref_mut();
-    let old_best_utility = crit.donelist.first().map(|x|x.utility).unwrap_or(0);
+    let old_best_utility = crit.donelist.first().map(|x| x.utility).unwrap_or(0);
     let old_donelist_len = crit.donelist.len();
     let old_utility_pruning_cutoff = crit.utility_pruning_cutoff;
     // drain from donelist_buf into the actual donelist
-    crit.donelist.extend(donelist_buf.drain(..).filter(|done| done.utility > old_utility_pruning_cutoff));
-    if !shared.cfg.no_stats { shared.stats.lock().deref_mut().finished += crit.donelist.len() - old_donelist_len; };
+    crit.donelist.extend(
+        donelist_buf
+            .drain(..)
+            .filter(|done| done.utility > old_utility_pruning_cutoff),
+    );
+    if !shared.cfg.no_stats {
+        shared.stats.lock().deref_mut().finished += crit.donelist.len() - old_donelist_len;
+    };
     // sort + truncate + update utility_pruning_cutoff
     crit.update(&shared.cfg); // this also updates utility_pruning_cutoff
 
-    if shared.cfg.verbose_best && crit.donelist.first().map(|x|x.utility).unwrap_or(0) > old_best_utility {
-        println!("{} @ step={} util={} for {}", "[new best utility]".blue(), shared.stats.lock().deref_mut().worklist_steps, crit.donelist.first().unwrap().utility, crit.donelist.first().unwrap().info(shared));
+    if shared.cfg.verbose_best
+        && crit.donelist.first().map(|x| x.utility).unwrap_or(0) > old_best_utility
+    {
+        println!(
+            "{} @ step={} util={} for {}",
+            "[new best utility]".blue(),
+            shared.stats.lock().deref_mut().worklist_steps,
+            crit.donelist.first().unwrap().utility,
+            crit.donelist.first().unwrap().info(shared)
+        );
     }
 
     // pull out the newer version of this now that its been updated, since we're returning it at the end
@@ -726,19 +874,30 @@ fn get_worklist_item(
     let old_worklist_len = crit.worklist.len();
     let worklist_buf_len = worklist_buf.len();
     // drain from worklist_buf into the actual worklist
-    crit.worklist.extend(worklist_buf.drain(..).filter(|heap_item| heap_item.pattern.utility_upper_bound > utility_pruning_cutoff));
+    crit.worklist.extend(
+        worklist_buf
+            .drain(..)
+            .filter(|heap_item| heap_item.pattern.utility_upper_bound > utility_pruning_cutoff),
+    );
     // num pruned by upper bound = num we were gonna add minus change in worklist length
-    if !shared.cfg.no_stats { shared.stats.lock().deref_mut().upper_bound_fired += worklist_buf_len - (crit.worklist.len() - old_worklist_len); };
+    if !shared.cfg.no_stats {
+        shared.stats.lock().deref_mut().upper_bound_fired +=
+            worklist_buf_len - (crit.worklist.len() - old_worklist_len);
+    };
 
     let mut returned_items = vec![];
 
     // try to get a new worklist item
     crit.active_threads.remove(&thread::current().id()); // remove ourself from the active threads
-    // println!("worklist len: {}", crit.worklist.len());
+                                                         // println!("worklist len: {}", crit.worklist.len());
 
     loop {
         // with dynamic batch size, take worklist_size/num_threads items from the worklist
-        let batch_size = if shared.cfg.dynamic_batch { std::cmp::max(1, crit.worklist.len() / shared.cfg.threads ) } else { shared.cfg.batch };
+        let batch_size = if shared.cfg.dynamic_batch {
+            std::cmp::max(1, crit.worklist.len() / shared.cfg.threads)
+        } else {
+            shared.cfg.batch
+        };
         while crit.worklist.is_empty() {
             if !returned_items.is_empty() {
                 // give up and return whatever we've got
@@ -746,7 +905,7 @@ fn get_worklist_item(
                 return Some((returned_items, utility_pruning_cutoff));
             }
             if crit.active_threads.is_empty() {
-                return None // all threads are stuck waiting for work so we're all done
+                return None; // all threads are stuck waiting for work so we're all done
             }
             // the worklist is empty but someone else currently has a worklist item so we should give up our lock then take it back
             drop(shared_guard);
@@ -755,10 +914,11 @@ fn get_worklist_item(
             // update our cutoff in case it changed
             utility_pruning_cutoff = crit.utility_pruning_cutoff;
         }
-        
         let heap_item = crit.worklist.pop().unwrap();
         // prune if upper bound is too low (cutoff may have increased in the time since this was added to the worklist)
-        if shared.cfg.no_opt_upper_bound || heap_item.pattern.utility_upper_bound > utility_pruning_cutoff {
+        if shared.cfg.no_opt_upper_bound
+            || heap_item.pattern.utility_upper_bound > utility_pruning_cutoff
+        {
             // we got one!
             returned_items.push(heap_item.pattern);
             if returned_items.len() == batch_size {
@@ -767,7 +927,9 @@ fn get_worklist_item(
                 return Some((returned_items, utility_pruning_cutoff));
             }
         } else {
-            if !shared.cfg.no_stats { shared.stats.lock().deref_mut().upper_bound_fired += 1; };
+            if !shared.cfg.no_stats {
+                shared.stats.lock().deref_mut().upper_bound_fired += 1;
+            };
         }
     }
     // * MULTITHREADING: CRITICAL SECTION END *
@@ -803,38 +965,59 @@ fn get_worklist_item(
 // }
 
 /// The core top down branch and bound search
-fn stitch_search(
-    shared: Arc<SharedData>,
-) {
-    
+fn stitch_search(shared: Arc<SharedData>) {
     // local buffers to eventually pour into the global worklist and donelist when we take the mutex
     let mut worklist_buf: Vec<HeapItem> = Default::default();
     let mut donelist_buf: Vec<_> = Default::default();
 
     loop {
-
         // get a new worklist item along with pruning cutoffs
         let (patterns, mut weak_utility_pruning_cutoff) =
-            match get_worklist_item(
-                &mut worklist_buf,
-                &mut donelist_buf,
-                &shared,
-            ) {
+            match get_worklist_item(&mut worklist_buf, &mut donelist_buf, &shared) {
                 Some(pattern) => pattern,
                 None => return,
-        };
+            };
 
         for original_pattern in patterns {
-
-            if !shared.cfg.no_stats { shared.stats.lock().deref_mut().worklist_steps += 1; };
-            if !shared.cfg.no_stats { if shared.cfg.print_stats > 0 &&  shared.stats.lock().deref_mut().worklist_steps % shared.cfg.print_stats == 0 { println!("{:?} \n\t@ [bound={}; uses={}] chose: {}",shared.stats.lock().deref_mut(),   original_pattern.utility_upper_bound, original_pattern.match_locations.iter().map(|loc| shared.num_paths_to_node[usize::from(*loc)]).sum::<i32>(), original_pattern.to_expr(&shared)); }};
+            if !shared.cfg.no_stats {
+                shared.stats.lock().deref_mut().worklist_steps += 1;
+            };
+            if !shared.cfg.no_stats {
+                if shared.cfg.print_stats > 0
+                    && shared.stats.lock().deref_mut().worklist_steps % shared.cfg.print_stats == 0
+                {
+                    println!(
+                        "{:?} \n\t@ [bound={}; uses={}] chose: {}",
+                        shared.stats.lock().deref_mut(),
+                        original_pattern.utility_upper_bound,
+                        original_pattern
+                            .match_locations
+                            .iter()
+                            .map(|loc| shared.num_paths_to_node[usize::from(*loc)])
+                            .sum::<i32>(),
+                        original_pattern.to_expr(&shared)
+                    );
+                }
+            };
 
             if shared.cfg.verbose_worklist {
-                println!("[bound={}; uses={}] chose: {}", original_pattern.utility_upper_bound, original_pattern.match_locations.iter().map(|loc| shared.num_paths_to_node[usize::from(*loc)]).sum::<i32>(), original_pattern.to_expr(&shared));
+                println!(
+                    "[bound={}; uses={}] chose: {}",
+                    original_pattern.utility_upper_bound,
+                    original_pattern
+                        .match_locations
+                        .iter()
+                        .map(|loc| shared.num_paths_to_node[usize::from(*loc)])
+                        .sum::<i32>(),
+                    original_pattern.to_expr(&shared)
+                );
             }
 
             // choose which hole we're going to expand
-            let hole_idx: usize = shared.cfg.hole_choice.choose_hole(&original_pattern, &shared);
+            let hole_idx: usize = shared
+                .cfg
+                .hole_choice
+                .choose_hole(&original_pattern, &shared);
 
             // pop that hole form the list of holes
             let mut holes_after_pop: Vec<ZId> = original_pattern.holes.clone();
@@ -854,17 +1037,22 @@ fn stitch_search(
             let mut found_tracked = false;
             // for each way of expanding the hole...
 
-            'expansion:
-                for (expands_to, locs) in match_locations.into_iter()
-                .group_by(|loc| &arg_of_loc[loc].expands_to).into_iter()
+            'expansion: for (expands_to, locs) in match_locations
+                .into_iter()
+                .group_by(|loc| &arg_of_loc[loc].expands_to)
+                .into_iter()
                 .map(|(expands_to, locs)| (expands_to.clone(), locs.collect::<Vec<Id>>()))
                 .chain(ivars_expansions.into_iter())
             {
                 // for debugging
-                let tracked = original_pattern.tracked && expands_to == tracked_expands_to(&original_pattern, hole_zid, &shared);
-                if tracked { found_tracked = true; }
-                if shared.cfg.follow_track && !tracked { continue 'expansion; }
-
+                let tracked = original_pattern.tracked
+                    && expands_to == tracked_expands_to(&original_pattern, hole_zid, &shared);
+                if tracked {
+                    found_tracked = true;
+                }
+                if shared.cfg.follow_track && !tracked {
+                    continue 'expansion;
+                }
 
                 // prune inventions that only match at a single unique (structurally hashed) subtree. This only applies if we
                 // also are priming with arity 0 inventions. Basically if something only matches at one subtree then the best you can
@@ -872,17 +1060,41 @@ fn stitch_search(
                 // prune here. The exception is when there are free variables so arity 0 wouldn't have applied.
                 // Also, note that upper bounding + arity 0 priming does nearly perfectly handle this already, but there are cases where
                 // you can't improve your structure penalty bound enough to catch everything hence this separate single_use thing.
-                if !shared.cfg.no_opt_single_use && !shared.cfg.no_opt_arity_zero && locs.len()  == 1 && shared.free_vars_of_node[usize::from(locs[0])].is_empty() {
-                    if !shared.cfg.no_stats { shared.stats.lock().deref_mut().single_use_fired += 1; }
+                if !shared.cfg.no_opt_single_use
+                    && !shared.cfg.no_opt_arity_zero
+                    && locs.len() == 1
+                    && shared.free_vars_of_node[usize::from(locs[0])].is_empty()
+                {
+                    if !shared.cfg.no_stats {
+                        shared.stats.lock().deref_mut().single_use_fired += 1;
+                    }
                     continue 'expansion;
                 }
 
                 // prune inventions specific to one single task
                 if !shared.cfg.no_opt_single_task
-                        && locs.iter().all(|node| shared.tasks_of_node[usize::from(*node)].len() == 1)
-                        && locs.iter().all(|node| shared.tasks_of_node[usize::from(locs[0])].iter().next() == shared.tasks_of_node[usize::from(*node)].iter().next()) {
-                    if !shared.cfg.no_stats { shared.stats.lock().deref_mut().single_task_fired += 1; }
-                    if tracked { println!("{} single task pruned when expanding {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), original_pattern.to_expr(&shared).zipper_replace(&shared.zip_of_zid[hole_zid], &format!("<{}>",expands_to))); }
+                    && locs
+                        .iter()
+                        .all(|node| shared.tasks_of_node[usize::from(*node)].len() == 1)
+                    && locs.iter().all(|node| {
+                        shared.tasks_of_node[usize::from(locs[0])].iter().next()
+                            == shared.tasks_of_node[usize::from(*node)].iter().next()
+                    })
+                {
+                    if !shared.cfg.no_stats {
+                        shared.stats.lock().deref_mut().single_task_fired += 1;
+                    }
+                    if tracked {
+                        println!(
+                            "{} single task pruned when expanding {} to {}",
+                            "[TRACK]".red().bold(),
+                            original_pattern.to_expr(&shared),
+                            original_pattern.to_expr(&shared).zipper_replace(
+                                &shared.zip_of_zid[hole_zid],
+                                &format!("<{}>", expands_to)
+                            )
+                        );
+                    }
                     continue 'expansion;
                 }
 
@@ -890,9 +1102,22 @@ fn stitch_search(
                 // Here we just check if our expansion just yielded a variable, and if that is bound based on how many lambdas there are above it.
                 if true || !shared.cfg.no_opt_free_vars {
                     if let ExpandsTo::Var(i) = expands_to {
-                        if i >= shared.zip_of_zid[hole_zid].iter().filter(|znode|**znode == ZNode::Body).count() as i32 {
-                            if !shared.cfg.no_stats { shared.stats.lock().deref_mut().free_vars_fired += 1; };
-                            if tracked { println!("{} pruned by free var in body when expanding {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared)); }
+                        if i >= shared.zip_of_zid[hole_zid]
+                            .iter()
+                            .filter(|znode| **znode == ZNode::Body)
+                            .count() as i32
+                        {
+                            if !shared.cfg.no_stats {
+                                shared.stats.lock().deref_mut().free_vars_fired += 1;
+                            };
+                            if tracked {
+                                println!(
+                                    "{} pruned by free var in body when expanding {} to {}",
+                                    "[TRACK]".red().bold(),
+                                    original_pattern.to_expr(&shared),
+                                    original_pattern.show_track_expansion(hole_zid, &shared)
+                                );
+                            }
                             continue 'expansion; // free var
                         }
                     }
@@ -901,36 +1126,55 @@ fn stitch_search(
                 // check for useless abstractions (ie ones that take the same arg everywhere). We check for this all the time, not just when adding a new variables,
                 // because subsetting of match_locations can turn previously useful abstractions into useless ones.
                 if !shared.cfg.no_opt_useless_abstract {
-                    for argchoice in original_pattern.arg_choices.iter(){
+                    for argchoice in original_pattern.arg_choices.iter() {
                         // if its the same arg in every place
                         if locs.iter().map(|loc| shared.arg_of_zid_node[argchoice.zid][loc].shifted_id).all_equal()
                             // AND there's no potential for refining that arg
                             && (!shared.cfg.refine || locs.iter().all(|loc| shared.free_vars_of_node[usize::from(shared.arg_of_zid_node[argchoice.zid][loc].shifted_id)].is_empty()))
                         {
-                            if !shared.cfg.no_stats { shared.stats.lock().deref_mut().useless_abstract_fired += 1; };
+                            if !shared.cfg.no_stats {
+                                shared.stats.lock().deref_mut().useless_abstract_fired += 1;
+                            };
                             continue 'expansion; // useless abstraction
                         }
                     }
-
                 }
 
-
                 // update the body utility
-                let body_utility_no_refinement = original_pattern.body_utility_no_refinement +  match expands_to {
-                    ExpandsTo::Lam | ExpandsTo::App => COST_NONTERMINAL,
-                    ExpandsTo::Var(_) | ExpandsTo::Prim(_) => COST_TERMINAL,
-                    ExpandsTo::IVar(_) => 0,
-                };
+                let body_utility_no_refinement = original_pattern.body_utility_no_refinement
+                    + match expands_to {
+                        ExpandsTo::Lam | ExpandsTo::App => COST_NONTERMINAL,
+                        ExpandsTo::Var(_) | ExpandsTo::Prim(_) => COST_TERMINAL,
+                        ExpandsTo::IVar(_) => 0,
+                    };
                 let refinement_body_utility = original_pattern.refinement_body_utility;
 
                 // update the upper bound
-                let util_upper_bound: i32 = utility_upper_bound(&locs, body_utility_no_refinement + refinement_body_utility, &shared.cost_of_node_all, &shared.num_paths_to_node, &shared.cfg);
+                let util_upper_bound: i32 = utility_upper_bound(
+                    &locs,
+                    body_utility_no_refinement + refinement_body_utility,
+                    &shared.cost_of_node_all,
+                    &shared.num_paths_to_node,
+                    &shared.cfg,
+                );
                 assert!(util_upper_bound <= original_pattern.utility_upper_bound);
 
                 // branch and bound: if the upper bound is less than the best invention we've found so far (our cutoff), we can discard this pattern
-                if !shared.cfg.no_opt_upper_bound && util_upper_bound <= weak_utility_pruning_cutoff {
-                    if !shared.cfg.no_stats { shared.stats.lock().deref_mut().upper_bound_fired += 1; };
-                    if tracked { println!("{} upper bound ({} < {}) pruned when expanding {} to {}", "[TRACK]".red().bold(), util_upper_bound, weak_utility_pruning_cutoff, original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared)); }
+                if !shared.cfg.no_opt_upper_bound && util_upper_bound <= weak_utility_pruning_cutoff
+                {
+                    if !shared.cfg.no_stats {
+                        shared.stats.lock().deref_mut().upper_bound_fired += 1;
+                    };
+                    if tracked {
+                        println!(
+                            "{} upper bound ({} < {}) pruned when expanding {} to {}",
+                            "[TRACK]".red().bold(),
+                            util_upper_bound,
+                            weak_utility_pruning_cutoff,
+                            original_pattern.to_expr(&shared),
+                            original_pattern.show_track_expansion(hole_zid, &shared)
+                        );
+                    }
                     continue 'expansion; // too low utility
                 }
 
@@ -948,8 +1192,8 @@ fn stitch_search(
                     }
                     ExpandsTo::App => {
                         // add new holes
-                            holes.push(shared.extensions_of_zid[hole_zid].func.unwrap());
-                            holes.push(shared.extensions_of_zid[hole_zid].arg.unwrap());
+                        holes.push(shared.extensions_of_zid[hole_zid].func.unwrap());
+                        holes.push(shared.extensions_of_zid[hole_zid].arg.unwrap());
                     }
                     _ => {}
                 }
@@ -970,75 +1214,97 @@ fn stitch_search(
                 // happens here and not just at the ivar creation point because new subsetting can happen
                 if !shared.cfg.no_opt_force_multiuse {
                     // for all pairs of ivars #i and #j, get the first zipper and compare the arg value across all locations
-                    for (i,ivar_zid_1) in first_zid_of_ivar.iter().enumerate() {
+                    for (i, ivar_zid_1) in first_zid_of_ivar.iter().enumerate() {
                         let ref arg_of_loc_1 = shared.arg_of_zid_node[*ivar_zid_1];
-                        for ivar_zid_2 in first_zid_of_ivar.iter().skip(i+1) {
+                        for ivar_zid_2 in first_zid_of_ivar.iter().skip(i + 1) {
                             let ref arg_of_loc_2 = shared.arg_of_zid_node[*ivar_zid_2];
-                            if locs.iter().all(|loc|
-                                arg_of_loc_1[loc].shifted_id == arg_of_loc_2[loc].shifted_id)
-                            {
-                                if !shared.cfg.no_stats { shared.stats.lock().deref_mut().force_multiuse_fired += 1; };
-                                if tracked { println!("{} force multiuse pruned when expanding {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared)); }
+                            if locs.iter().all(|loc| {
+                                arg_of_loc_1[loc].shifted_id == arg_of_loc_2[loc].shifted_id
+                            }) {
+                                if !shared.cfg.no_stats {
+                                    shared.stats.lock().deref_mut().force_multiuse_fired += 1;
+                                };
+                                if tracked {
+                                    println!(
+                                        "{} force multiuse pruned when expanding {} to {}",
+                                        "[TRACK]".red().bold(),
+                                        original_pattern.to_expr(&shared),
+                                        original_pattern.show_track_expansion(hole_zid, &shared)
+                                    );
+                                }
                                 continue 'expansion;
                             }
                         }
                     }
                 }
 
-            // build our new pattern with all the variables we've just defined. Copy in the argchoices and prefixes
-            // from the old pattern.
-            let mut new_pattern = Pattern {
-                holes,
-                arg_choices,
-                first_zid_of_ivar,
-                refinements,
-                match_locations: locs,
-                utility_upper_bound: util_upper_bound,
-                body_utility_no_refinement,
-                refinement_body_utility,
-                tracked
-            };
+                // build our new pattern with all the variables we've just defined. Copy in the argchoices and prefixes
+                // from the old pattern.
+                let mut new_pattern = Pattern {
+                    holes,
+                    arg_choices,
+                    first_zid_of_ivar,
+                    refinements,
+                    match_locations: locs,
+                    utility_upper_bound: util_upper_bound,
+                    body_utility_no_refinement,
+                    refinement_body_utility,
+                    tracked,
+                };
 
-            // new_pattern.utility_upper_bound = utility_upper_bound_with_conflicts(&new_pattern, body_utility_no_refinement + refinement_body_utility, &shared);
-            // // branch and bound again
-            // if !shared.cfg.no_opt_upper_bound && new_pattern.utility_upper_bound <= weak_utility_pruning_cutoff {
-            //     if !shared.cfg.no_stats { shared.stats.lock().deref_mut().conflict_upper_bound_fired += 1; };
-            //     if tracked { println!("{} upper bound ({} < {}) pruned when expanding {} to {}", "[TRACK]".red().bold(), util_upper_bound, weak_utility_pruning_cutoff, original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared)); }
-            //     continue 'expansion; // too low utility
-            // }
+                // new_pattern.utility_upper_bound = utility_upper_bound_with_conflicts(&new_pattern, body_utility_no_refinement + refinement_body_utility, &shared);
+                // // branch and bound again
+                // if !shared.cfg.no_opt_upper_bound && new_pattern.utility_upper_bound <= weak_utility_pruning_cutoff {
+                //     if !shared.cfg.no_stats { shared.stats.lock().deref_mut().conflict_upper_bound_fired += 1; };
+                //     if tracked { println!("{} upper bound ({} < {}) pruned when expanding {} to {}", "[TRACK]".red().bold(), util_upper_bound, weak_utility_pruning_cutoff, original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared)); }
+                //     continue 'expansion; // too low utility
+                // }
 
+                if new_pattern.holes.is_empty() {
+                    // it's a finished pattern
+                    // refinement
 
+                    if shared.cfg.refine {
+                        refine(&mut new_pattern, tracked, &shared);
+                    }
 
-            if new_pattern.holes.is_empty() {
-                // it's a finished pattern
-                // refinement
+                    let finished_pattern = FinishedPattern::new(new_pattern, &shared);
 
-                if shared.cfg.refine {
-                    refine(&mut new_pattern, tracked, &shared);
-                }
+                    if !shared.cfg.no_stats {
+                        shared.stats.lock().calc_final_utility += 1;
+                    };
 
-                let finished_pattern = FinishedPattern::new(new_pattern, &shared);
+                    if shared.cfg.rewrite_check {
+                        // run rewriting just to make sure the assert in it passes
+                        rewrite_fast(&finished_pattern, &shared, &"fake_inv");
+                    }
 
-                if !shared.cfg.no_stats { shared.stats.lock().calc_final_utility += 1; };
+                    if tracked {
+                        println!(
+                            "{} pushed {} to donelist (util: {})",
+                            "[TRACK:DONE]".green().bold(),
+                            finished_pattern.to_expr(&shared),
+                            finished_pattern.utility
+                        );
+                    }
+                    if shared.cfg.inv_candidates == 1
+                        && finished_pattern.utility > weak_utility_pruning_cutoff
+                    {
+                        // if we're only looking for one invention, we can directly update our cutoff here
+                        weak_utility_pruning_cutoff = finished_pattern.utility;
+                    }
 
-                if shared.cfg.rewrite_check {
-                    // run rewriting just to make sure the assert in it passes
-                    rewrite_fast(&finished_pattern, &shared, &"fake_inv");
-                }
-
-                if tracked {
-                    println!("{} pushed {} to donelist (util: {})", "[TRACK:DONE]".green().bold(), finished_pattern.to_expr(&shared), finished_pattern.utility);
-                }
-                if shared.cfg.inv_candidates == 1 && finished_pattern.utility > weak_utility_pruning_cutoff {
-                    // if we're only looking for one invention, we can directly update our cutoff here
-                    weak_utility_pruning_cutoff = finished_pattern.utility;
-                }
-
-                donelist_buf.push(finished_pattern);
-
+                    donelist_buf.push(finished_pattern);
                 } else {
                     // it's a partial pattern so just add it to the worklist
-                    if tracked { println!("{} pushed {} to work list (bound: {})", "[TRACK]".green().bold(), original_pattern.show_track_expansion(hole_zid, &shared), new_pattern.utility_upper_bound); }
+                    if tracked {
+                        println!(
+                            "{} pushed {} to work list (bound: {})",
+                            "[TRACK]".green().bold(),
+                            original_pattern.show_track_expansion(hole_zid, &shared),
+                            new_pattern.utility_upper_bound
+                        );
+                    }
                     worklist_buf.push(HeapItem::new(new_pattern))
                 }
             }
@@ -1047,25 +1313,31 @@ fn stitch_search(
                 // let new = format!("<{}>",tracked_expands_to(&original_pattern, hole_zid, &shared));
                 // let mut s = original_pattern.to_expr(&shared).zipper_replace(&shared.zip_of_zid[hole_zid], &new ).to_string();
                 // s = s.replace(&new, &new.clone().magenta().bold().to_string());
-            println!("{} pruned when expanding because there were no match locations for the target expansion of {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared));
+                println!("{} pruned when expanding because there were no match locations for the target expansion of {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), original_pattern.show_track_expansion(hole_zid, &shared));
             }
-        
         }
     }
-
 }
 
 #[inline(never)]
-fn get_ivars_expansions(original_pattern: &Pattern, arg_of_loc: &AHashMap<Id,Arg>, shared: &Arc<SharedData>) -> Vec<(ExpandsTo, Vec<Id>)> {
+fn get_ivars_expansions(
+    original_pattern: &Pattern,
+    arg_of_loc: &AHashMap<Id, Arg>,
+    shared: &Arc<SharedData>,
+) -> Vec<(ExpandsTo, Vec<Id>)> {
     let mut ivars_expansions = vec![];
     // consider all ivars used previously
     for ivar in 0..original_pattern.first_zid_of_ivar.len() {
         let ref arg_of_loc_ivar = shared.arg_of_zid_node[original_pattern.first_zid_of_ivar[ivar]];
-        let locs: Vec<Id> = original_pattern.match_locations.iter()
-            .filter(|loc|
-                arg_of_loc[loc].shifted_id == 
-                arg_of_loc_ivar[loc].shifted_id).cloned().collect();
-        if locs.is_empty() { continue; }
+        let locs: Vec<Id> = original_pattern
+            .match_locations
+            .iter()
+            .filter(|loc| arg_of_loc[loc].shifted_id == arg_of_loc_ivar[loc].shifted_id)
+            .cloned()
+            .collect();
+        if locs.is_empty() {
+            continue;
+        }
         ivars_expansions.push((ExpandsTo::IVar(ivar as i32), locs));
     }
     // also consider one ivar greater, if this is within the arity limit. This will match at all the same locations as the original.
@@ -1081,62 +1353,112 @@ fn get_ivars_expansions(original_pattern: &Pattern, arg_of_loc: &AHashMap<Id,Arg
 #[inline(never)]
 pub fn refine(new_pattern: &mut Pattern, tracked: bool, shared: &SharedData) {
     if tracked {
-        println!("{} refining {}", "[TRACK:REFINE]".yellow().bold(), new_pattern.to_expr(&shared));
+        println!(
+            "{} refining {}",
+            "[TRACK:REFINE]".yellow().bold(),
+            new_pattern.to_expr(&shared)
+        );
     }
 
     let mut best_refinement: Vec<Option<Vec<Id>>> = new_pattern.refinements.clone(); // initially all Nones
-    let mut best_utility = noncompressive_utility(new_pattern.body_utility_no_refinement + new_pattern.refinement_body_utility, &shared.cfg) + compressive_utility(&new_pattern,&shared).util;
+    let mut best_utility = noncompressive_utility(
+        new_pattern.body_utility_no_refinement + new_pattern.refinement_body_utility,
+        &shared.cfg,
+    ) + compressive_utility(&new_pattern, &shared).util;
     let mut best_refinement_body_utility = 0;
     assert!(new_pattern.refinement_body_utility == 0);
-    assert!(new_pattern.refinements.iter().all(|refinement| refinement.is_none()));
+    assert!(new_pattern
+        .refinements
+        .iter()
+        .all(|refinement| refinement.is_none()));
 
     // get all refinement options for each arg, deduped
-    let mut refinements_by_arg: Vec<Vec<Id>> = new_pattern.first_zid_of_ivar.iter().map(|zid| 
-        new_pattern.match_locations.iter().flat_map(|loc|
-            shared.uses_of_shifted_arg_refinement.get(&shared.arg_of_zid_node[*zid][loc].shifted_id).map(|uses_of_refinement| uses_of_refinement.keys())
-        ).flatten().cloned().collect::<AHashSet<_>>().into_iter().collect()).collect();
+    let mut refinements_by_arg: Vec<Vec<Id>> = new_pattern
+        .first_zid_of_ivar
+        .iter()
+        .map(|zid| {
+            new_pattern
+                .match_locations
+                .iter()
+                .flat_map(|loc| {
+                    shared
+                        .uses_of_shifted_arg_refinement
+                        .get(&shared.arg_of_zid_node[*zid][loc].shifted_id)
+                        .map(|uses_of_refinement| uses_of_refinement.keys())
+                })
+                .flatten()
+                .cloned()
+                .collect::<AHashSet<_>>()
+                .into_iter()
+                .collect()
+        })
+        .collect();
 
-    for (i,_) in new_pattern.first_zid_of_ivar.iter().enumerate() { // for each arg
-        if new_pattern.arg_choices.iter().filter(|l |l.ivar == i).count() > 1 {
+    for (i, _) in new_pattern.first_zid_of_ivar.iter().enumerate() {
+        // for each arg
+        if new_pattern
+            .arg_choices
+            .iter()
+            .filter(|l| l.ivar == i)
+            .count()
+            > 1
+        {
             refinements_by_arg[i] = Vec::new(); // todo limitation: we dont refine multiuse
         }
     }
 
     let mut num_refinements = 0;
 
-    'refinements: for refinements in refinements_by_arg.into_iter()
-        .map(|refinements|
-                (1..=shared.cfg.max_refinement_arity).map(move |k| refinements.clone().into_iter()
-                    .combinations(k))
+    'refinements: for refinements in refinements_by_arg
+        .into_iter()
+        .map(|refinements| {
+            (1..=shared.cfg.max_refinement_arity)
+                .map(move |k| refinements.clone().into_iter().combinations(k))
                 .flatten()
                 .map(|r| Some(r))
                 .chain(std::iter::once(None))
-                )
+        })
         .multi_cartesian_product()
     {
         num_refinements += 1;
         // insert the refinement
         new_pattern.refinements = refinements.clone();
         // body grows by an APP and the refined out subtree's size
-        new_pattern.refinement_body_utility = refinements.iter()
+        new_pattern.refinement_body_utility = refinements
+            .iter()
             .flat_map(|r| r)
-            .map(|r| r.iter()
-                .map(|r_id| COST_NONTERMINAL + shared.cost_of_node_once[usize::from(*r_id)]).sum::<i32>()).sum::<i32>();
+            .map(|r| {
+                r.iter()
+                    .map(|r_id| COST_NONTERMINAL + shared.cost_of_node_once[usize::from(*r_id)])
+                    .sum::<i32>()
+            })
+            .sum::<i32>();
 
-        let utility = noncompressive_utility(new_pattern.body_utility_no_refinement + new_pattern.refinement_body_utility, &shared.cfg) + compressive_utility(&new_pattern,&shared).util;
+        let utility = noncompressive_utility(
+            new_pattern.body_utility_no_refinement + new_pattern.refinement_body_utility,
+            &shared.cfg,
+        ) + compressive_utility(&new_pattern, &shared).util;
         if utility > best_utility {
             best_refinement = refinements.clone();
             best_utility = utility;
             best_refinement_body_utility = new_pattern.refinement_body_utility;
         }
         if tracked {
-            println!("{} refined to {} (util: {})", "[TRACK:REFINE]".yellow().bold(), new_pattern.to_expr(&shared), utility);
+            println!(
+                "{} refined to {} (util: {})",
+                "[TRACK:REFINE]".yellow().bold(),
+                new_pattern.to_expr(&shared),
+                utility
+            );
             println!("{:?}", refinements);
             if let Some(track_refined) = &shared.tracking.as_ref().unwrap().refined {
                 let refined = new_pattern.to_expr(&shared).to_string();
                 let track_refined = track_refined.to_string();
                 if refined == track_refined {
-                    println!("{} previous refinement was the tracked one! Forcing it to accept that one", "[TRACK:REFINE]".green().bold());
+                    println!(
+                        "{} previous refinement was the tracked one! Forcing it to accept that one",
+                        "[TRACK:REFINE]".green().bold()
+                    );
                     best_refinement = refinements.clone();
                     best_refinement_body_utility = new_pattern.refinement_body_utility;
                     new_pattern.refinement_body_utility = 0;
@@ -1148,15 +1470,17 @@ pub fn refine(new_pattern: &mut Pattern, tracked: bool, shared: &SharedData) {
         new_pattern.refinement_body_utility = 0;
     }
     if num_refinements > 1000 {
-        println!("[many refinements] tried {} refinements for {}", num_refinements, new_pattern.to_expr(&shared));
+        println!(
+            "[many refinements] tried {} refinements for {}",
+            num_refinements,
+            new_pattern.to_expr(&shared)
+        );
     }
 
     // set to the best
     new_pattern.refinements = best_refinement.clone();
     new_pattern.refinement_body_utility = best_refinement_body_utility;
 }
-
-
 
 /// A finished invention
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1173,11 +1497,24 @@ impl FinishedPattern {
     #[inline(never)]
     fn new(pattern: Pattern, shared: &SharedData) -> Self {
         let arity = pattern.first_zid_of_ivar.len();
-        let usages = pattern.match_locations.iter().map(|loc| shared.num_paths_to_node[usize::from(*loc)]).sum();
-        let compressive_utility = compressive_utility(&pattern,shared);
-        let noncompressive_utility = noncompressive_utility(pattern.body_utility_no_refinement + pattern.refinement_body_utility, &shared.cfg);
+        let usages = pattern
+            .match_locations
+            .iter()
+            .map(|loc| shared.num_paths_to_node[usize::from(*loc)])
+            .sum();
+        let compressive_utility = compressive_utility(&pattern, shared);
+        let noncompressive_utility = noncompressive_utility(
+            pattern.body_utility_no_refinement + pattern.refinement_body_utility,
+            &shared.cfg,
+        );
         let utility = noncompressive_utility + compressive_utility.util;
-        assert!(utility <= pattern.utility_upper_bound, "{} BUT utility is higher: {} (usages: {})", pattern.info(&shared), utility, usages);
+        assert!(
+            utility <= pattern.utility_upper_bound,
+            "{} BUT utility is higher: {} (usages: {})",
+            pattern.info(&shared),
+            utility,
+            usages
+        );
         FinishedPattern {
             pattern,
             utility,
@@ -1195,9 +1532,15 @@ impl FinishedPattern {
         Invention::new(self.to_expr(shared), self.arity, name)
     }
     pub fn info(&self, shared: &SharedData) -> String {
-        format!("{} -> finished: utility={}, compressive_utility={}, arity={}, usages={}",self.pattern.info(shared), self.utility, self.compressive_utility, self.arity, self.usages)
+        format!(
+            "{} -> finished: utility={}, compressive_utility={}, arity={}, usages={}",
+            self.pattern.info(shared),
+            self.utility,
+            self.compressive_utility,
+            self.arity,
+            self.usages
+        )
     }
-
 }
 // #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 // struct Refinement {
@@ -1207,14 +1550,21 @@ impl FinishedPattern {
 // }
 
 /// return all possible refinements you could use here along with counts for how many of each you can use
-fn get_refinements_of_shifted_id(shifted_id: Id, egraph: &crate::EGraph, cfg: &CompressionStepConfig) -> AHashMap<Id,usize>
-{
-    fn helper(id: Id, egraph: &crate::EGraph, cfg: &CompressionStepConfig, refinements: &mut Vec<Id>) {
-        let ivars =  egraph[id].data.free_ivars.len();
+fn get_refinements_of_shifted_id(
+    shifted_id: Id,
+    egraph: &crate::EGraph,
+    cfg: &CompressionStepConfig,
+) -> AHashMap<Id, usize> {
+    fn helper(
+        id: Id,
+        egraph: &crate::EGraph,
+        cfg: &CompressionStepConfig,
+        refinements: &mut Vec<Id>,
+    ) {
+        let ivars = egraph[id].data.free_ivars.len();
         if ivars == 0 {
             return; // todo limitation: we dont thread things that dont have ivars, for sortof good reasons.
         }
-        
         if !egraph[id].data.free_vars.is_empty() {
             return; // if something has free vars and theyre not turned into ivars they must either be refs to lambdas within the arg or refs ABOVE the invention which in either case we can't refine
         }
@@ -1241,26 +1591,34 @@ fn get_zippers(
     cost_of_node_once: &Vec<i32>,
     no_cache: bool,
     egraph: &mut crate::EGraph,
-    cfg: &CompressionStepConfig
-) -> (AHashMap<Zip, ZId>, Vec<Zip>, Vec<AHashMap<Id,Arg>>, AHashMap<Id,Vec<ZId>>,  Vec<ZIdExtension>, AHashMap<Id,AHashMap<Id,usize>>) {
-    let cache: &mut Option<RecVarModCache> = &mut if no_cache { None } else { Some(AHashMap::new()) };
+    cfg: &CompressionStepConfig,
+) -> (
+    AHashMap<Zip, ZId>,
+    Vec<Zip>,
+    Vec<AHashMap<Id, Arg>>,
+    AHashMap<Id, Vec<ZId>>,
+    Vec<ZIdExtension>,
+    AHashMap<Id, AHashMap<Id, usize>>,
+) {
+    let cache: &mut Option<RecVarModCache> = &mut if no_cache {
+        None
+    } else {
+        Some(AHashMap::new())
+    };
 
     let mut zid_of_zip: AHashMap<Zip, ZId> = Default::default();
     let mut zip_of_zid: Vec<Zip> = Default::default();
-    let mut arg_of_zid_node: Vec<AHashMap<Id,Arg>> = Default::default();
-    let mut zids_of_node: AHashMap<Id,Vec<ZId>> = Default::default();
-
+    let mut arg_of_zid_node: Vec<AHashMap<Id, Arg>> = Default::default();
+    let mut zids_of_node: AHashMap<Id, Vec<ZId>> = Default::default();
 
     // let mut refinements_of_shifted_arg: AHashMap<Id,AHashSet<Id>> = Default::default();
     // let mut uses_of_zid_refinable_loc: AHashMap<(ZId,Id,Id),i32> = Default::default();
-    let mut uses_of_shifted_arg_refinement: AHashMap<Id,AHashMap<Id,usize>> = Default::default();
-
+    let mut uses_of_shifted_arg_refinement: AHashMap<Id, AHashMap<Id, usize>> = Default::default();
 
     zid_of_zip.insert(vec![], EMPTY_ZID);
     zip_of_zid.push(vec![]);
     arg_of_zid_node.push(AHashMap::new());
     assert!(EMPTY_ZID == 0);
-    
     // loop over all nodes in all programs in bottom up order
     for treenode in treenodes.iter() {
         // println!("processing id={}: {}", treenode, extract(*treenode, egraph) );
@@ -1269,21 +1627,29 @@ fn get_zippers(
         assert!(egraph[*treenode].nodes.len() == 1);
         // clone to appease the borrow checker
         let node = egraph[*treenode].nodes[0].clone();
-        
         // any node can become the identity function (the empty zipper with itself as the arg)
         let mut zids: Vec<ZId> = vec![EMPTY_ZID];
-        arg_of_zid_node[EMPTY_ZID].insert(*treenode,
-            Arg { shifted_id: *treenode, unshifted_id: *treenode, shift: 0, cost: cost_of_node_once[usize::from(*treenode)], expands_to: expands_to_of_node(&node) });
-        
+        arg_of_zid_node[EMPTY_ZID].insert(
+            *treenode,
+            Arg {
+                shifted_id: *treenode,
+                unshifted_id: *treenode,
+                shift: 0,
+                cost: cost_of_node_once[usize::from(*treenode)],
+                expands_to: expands_to_of_node(&node),
+            },
+        );
         match node {
-            Lambda::IVar(_) => { panic!("attempted to abstract an IVar") }
-            Lambda::Var(_) | Lambda::Prim(_) | Lambda::Programs(_) => {},
-            Lambda::App([f,x]) => {
+            Lambda::IVar(_) => {
+                panic!("attempted to abstract an IVar")
+            }
+            Lambda::Var(_) | Lambda::Prim(_) | Lambda::Programs(_) => {}
+            Lambda::App([f, x]) => {
                 // bubble from `f`
                 for f_zid in zids_of_node[&f].iter() {
                     // clone and extend zip to get new zid for this node
                     let mut zip = zip_of_zid[*f_zid].clone();
-                    zip.insert(0,ZNode::Func);
+                    zip.insert(0, ZNode::Func);
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip);
@@ -1301,7 +1667,7 @@ fn get_zippers(
                 for x_zid in zids_of_node[&x].iter() {
                     // clone and extend zip to get new zid for this node
                     let mut zip = zip_of_zid[*x_zid].clone();
-                    zip.insert(0,ZNode::Arg);
+                    zip.insert(0, ZNode::Arg);
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip);
@@ -1313,15 +1679,13 @@ fn get_zippers(
                     // give it the same arg
                     let arg = arg_of_zid_node[*x_zid][&x].clone();
                     arg_of_zid_node[*zid].insert(*treenode, arg);
-
                 }
-            },
+            }
             Lambda::Lam([b]) => {
                 for b_zid in zids_of_node[&b].iter() {
-
                     // clone and extend zip to get new zid for this node
                     let mut zip = zip_of_zid[*b_zid].clone();
-                    zip.insert(0,ZNode::Body);
+                    zip.insert(0, ZNode::Body);
                     let zid = zid_of_zip.entry(zip.clone()).or_insert_with(|| {
                         let zid = zip_of_zid.len();
                         zip_of_zid.push(zip.clone());
@@ -1344,46 +1708,58 @@ fn get_zippers(
                             // we  go one less than the depth from the root to the arg. That way $0 when we're hopping
                             // the only  lambda in existence will map to depth_root_to_arg-1 = 1-1 = 0 -> #0 which will then
                             // be transformed back #0 -> $0 + depth = $0 + 0 = $0 if we thread it directly for example.
-                            let depth_root_to_arg = zip.iter().filter(|x| **x == ZNode::Body).count() as i32;
-                            arg.shifted_id = insert_arg_ivars(arg.shifted_id, depth_root_to_arg-1, egraph).unwrap();
+                            let depth_root_to_arg =
+                                zip.iter().filter(|x| **x == ZNode::Body).count() as i32;
+                            arg.shifted_id =
+                                insert_arg_ivars(arg.shifted_id, depth_root_to_arg - 1, egraph)
+                                    .unwrap();
                         }
                         arg.shifted_id = shift(arg.shifted_id, -1, egraph, cache).unwrap();
                         arg.shift -= 1;
                         if cfg.refine {
                             // refinements:
                             if !uses_of_shifted_arg_refinement.contains_key(&arg.shifted_id) {
-                                uses_of_shifted_arg_refinement.insert(arg.shifted_id,get_refinements_of_shifted_id(arg.shifted_id, &egraph, cfg));
+                                uses_of_shifted_arg_refinement.insert(
+                                    arg.shifted_id,
+                                    get_refinements_of_shifted_id(arg.shifted_id, &egraph, cfg),
+                                );
                             }
                             // refinements_of_shifted_arg.entry(arg.shifted_id).or_default().extend(refinement_counts.keys().cloned());
                             // uses_of_zid_refinable_loc
                         }
                     }
                     arg_of_zid_node[*zid].insert(*treenode, arg);
-                }            },
+                }
+            }
         }
         zids_of_node.insert(*treenode, zids);
     }
 
-    let extensions_of_zid = zip_of_zid.iter().map(|zip| {
-        let mut zip_body = zip.clone();
-        zip_body.push(ZNode::Body);
-        let mut zip_arg = zip.clone();
-        zip_arg.push(ZNode::Arg);
-        let mut zip_func = zip.clone();
-        zip_func.push(ZNode::Func);
-        ZIdExtension {
-            body: zid_of_zip.get(&zip_body).copied(),
-            arg: zid_of_zip.get(&zip_arg).copied(),
-            func: zid_of_zip.get(&zip_func).copied(),
-        }
-    }).collect();
+    let extensions_of_zid = zip_of_zid
+        .iter()
+        .map(|zip| {
+            let mut zip_body = zip.clone();
+            zip_body.push(ZNode::Body);
+            let mut zip_arg = zip.clone();
+            zip_arg.push(ZNode::Arg);
+            let mut zip_func = zip.clone();
+            zip_func.push(ZNode::Func);
+            ZIdExtension {
+                body: zid_of_zip.get(&zip_body).copied(),
+                arg: zid_of_zip.get(&zip_arg).copied(),
+                func: zid_of_zip.get(&zip_func).copied(),
+            }
+        })
+        .collect();
 
-    (zid_of_zip,
-    zip_of_zid,
-    arg_of_zid_node,
-    zids_of_node,
-    extensions_of_zid,
-    uses_of_shifted_arg_refinement)
+    (
+        zid_of_zip,
+        zip_of_zid,
+        arg_of_zid_node,
+        zids_of_node,
+        extensions_of_zid,
+        uses_of_shifted_arg_refinement,
+    )
 }
 
 /// the complete result of a single step of compression, this is a somewhat expensive data structure
@@ -1406,55 +1782,123 @@ pub struct CompressionStepResult {
 }
 
 impl CompressionStepResult {
-    fn new(done: FinishedPattern, inv_name: &str, shared: &mut SharedData, past_invs: &Vec<CompressionStepResult>) -> Self {
-
+    fn new(
+        done: FinishedPattern,
+        inv_name: &str,
+        shared: &mut SharedData,
+        past_invs: &Vec<CompressionStepResult>,
+        prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
+    ) -> Self {
         // cost of the very first initial program before any inventions
-        let very_first_cost = if let Some(past_inv) = past_invs.first() { past_inv.initial_cost } else { shared.init_cost };
+        let very_first_cost = if let Some(past_inv) = past_invs.first() {
+            past_inv.initial_cost
+        } else {
+            shared.init_cost
+        };
 
         let inv = done.to_invention(inv_name, shared);
         let rewritten = Expr::programs(rewrite_fast(&done, &shared, &inv.name));
 
-
         let expected_cost = shared.init_cost - done.compressive_utility;
         let final_cost = rewritten.cost();
         if expected_cost != final_cost {
-            println!("*** expected cost {} != final cost {}", expected_cost, final_cost);
+            println!(
+                "*** expected cost {} != final cost {}",
+                expected_cost, final_cost
+            );
         }
         let multiplier = shared.init_cost as f64 / final_cost as f64;
         let multiplier_wrt_orig = very_first_cost as f64 / final_cost as f64;
         let uses = done.usages;
-        let use_exprs: Vec<Expr> = done.pattern.match_locations.iter().map(|node| extract(*node, &shared.egraph)).collect();
-        let use_args: Vec<Vec<Expr>> = done.pattern.match_locations.iter().map(|node|
-            done.pattern.first_zid_of_ivar.iter().map(|zid|
-                extract(shared.arg_of_zid_node[*zid][node].shifted_id, &shared.egraph)
-            ).collect()).collect();
-        
+        let use_exprs: Vec<Expr> = done
+            .pattern
+            .match_locations
+            .iter()
+            .map(|node| extract(*node, &shared.egraph))
+            .collect();
+        let use_args: Vec<Vec<Expr>> = done
+            .pattern
+            .match_locations
+            .iter()
+            .map(|node| {
+                done.pattern
+                    .first_zid_of_ivar
+                    .iter()
+                    .map(|zid| {
+                        extract(
+                            shared.arg_of_zid_node[*zid][node].shifted_id,
+                            &shared.egraph,
+                        )
+                    })
+                    .collect()
+            })
+            .collect();
         // dreamcoder compatability
-        let dc_inv_str: String = dc_inv_str(&inv, past_invs);
+        let dc_inv_str: String = dc_inv_str(&inv, past_invs, prev_dc_inv_to_inv_strs);
         // Rewrite to dreamcoder syntax with all past invention
         // we rewrite "inv1)" and "inv1 " instead of just "inv1" because we dont want to match on "inv10"
-        let rewritten_dreamcoder: Vec<String> = rewritten.split_programs().iter().map(|p|{
-            let mut res = p.to_string();
-            for past_inv in past_invs {
-                res = replace_prim_with(&res, &past_inv.inv.name, &past_inv.dc_inv_str);
-                // res = res.replace(&format!("{})",past_inv.inv.name), &format!("{})",past_inv.dc_inv_str));
-                // res = res.replace(&format!("{} ",past_inv.inv.name), &format!("{} ",past_inv.dc_inv_str));
-            }
-            res = replace_prim_with(&res, &inv_name, &dc_inv_str);
-            // res = res.replace(&format!("{})",inv_name), &format!("{})",dc_inv_str));
-            // res = res.replace(&format!("{} ",inv_name), &format!("{} ",dc_inv_str));
-            res = res.replace("(lam ","(lambda ");
-            res
-        }).collect();
+        let rewritten_dreamcoder: Vec<String> = rewritten
+            .split_programs()
+            .iter()
+            .map(|p| {
+                let mut res = p.to_string();
+                // Replace with any past inventions carried over from the existing DSL.
+                for (past_inv_name, past_dc_inv_str) in prev_dc_inv_to_inv_strs {
+                    res = replace_prim_with(&res, past_inv_name, past_dc_inv_str);
+                }
+                for past_inv in past_invs {
+                    res = replace_prim_with(&res, &past_inv.inv.name, &past_inv.dc_inv_str);
+                    // res = res.replace(&format!("{})",past_inv.inv.name), &format!("{})",past_inv.dc_inv_str));
+                    // res = res.replace(&format!("{} ",past_inv.inv.name), &format!("{} ",past_inv.dc_inv_str));
+                }
+                res = replace_prim_with(&res, &inv_name, &dc_inv_str);
+                // res = res.replace(&format!("{})",inv_name), &format!("{})",dc_inv_str));
+                // res = res.replace(&format!("{} ",inv_name), &format!("{} ",dc_inv_str));
+                res = res.replace("(lam ", "(lambda ");
+                res
+            })
+            .collect();
 
-        CompressionStepResult { inv, rewritten, rewritten_dreamcoder, done, expected_cost, final_cost, multiplier, multiplier_wrt_orig, uses, use_exprs, use_args, dc_inv_str, initial_cost: shared.init_cost }
+        CompressionStepResult {
+            inv,
+            rewritten,
+            rewritten_dreamcoder,
+            done,
+            expected_cost,
+            final_cost,
+            multiplier,
+            multiplier_wrt_orig,
+            uses,
+            use_exprs,
+            use_args,
+            dc_inv_str,
+            initial_cost: shared.init_cost,
+        }
     }
-    pub fn json(&self) -> serde_json::Value {        
+    pub fn json(&self) -> serde_json::Value {
         let use_exprs: Vec<String> = self.use_exprs.iter().map(|expr| expr.to_string()).collect();
-        let use_args: Vec<String> = self.use_args.iter().map(|args| format!("{} {}", self.inv.name, args.iter().map(|expr| expr.to_string()).collect::<Vec<String>>().join(" "))).collect();
-        let all_uses: Vec<serde_json::Value> = use_exprs.iter().zip(use_args.iter()).sorted().map(|(expr,args)| json!({args: expr})).collect();
+        let use_args: Vec<String> = self
+            .use_args
+            .iter()
+            .map(|args| {
+                format!(
+                    "{} {}",
+                    self.inv.name,
+                    args.iter()
+                        .map(|expr| expr.to_string())
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                )
+            })
+            .collect();
+        let all_uses: Vec<serde_json::Value> = use_exprs
+            .iter()
+            .zip(use_args.iter())
+            .sorted()
+            .map(|(expr, args)| json!({ args: expr }))
+            .collect();
 
-        json!({            
+        json!({
             "body": self.inv.body.to_string(),
             "dreamcoder": self.dc_inv_str,
             "arity": self.inv.arity,
@@ -1475,10 +1919,17 @@ impl CompressionStepResult {
 impl fmt::Display for CompressionStepResult {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.expected_cost != self.final_cost {
-            write!(f,"[cost mismatch of {}] ", self.expected_cost - self.final_cost)?;
+            write!(
+                f,
+                "[cost mismatch of {}] ",
+                self.expected_cost - self.final_cost
+            )?;
         }
-        write!(f, "utility: {} | final_cost: {} | {:.2}x | uses: {} | body: {}",
-            self.done.utility, self.final_cost, self.multiplier, self.uses, self.inv)
+        write!(
+            f,
+            "utility: {} | final_cost: {} | {:.2}x | uses: {} | body: {}",
+            self.done.utility, self.final_cost, self.multiplier, self.uses, self.inv
+        )
     }
 }
 
@@ -1498,14 +1949,13 @@ fn utility_upper_bound(
 /// This utility is just for any utility terms that we care about that don't directly correspond
 /// to changes in size that come from rewriting with an invention
 #[inline(never)]
-fn noncompressive_utility(
-    body_utility_with_refinement: i32,
-    cfg: &CompressionStepConfig,
-) -> i32 {
-    if cfg.no_other_util { return 0; }
+fn noncompressive_utility(body_utility_with_refinement: i32, cfg: &CompressionStepConfig) -> i32 {
+    if cfg.no_other_util {
+        return 0;
+    }
     // this is a bit like the structure penalty from dreamcoder except that
     // that penalty uses inlined versions of nested inventions.
-    let structure_penalty = - body_utility_with_refinement;
+    let structure_penalty = -body_utility_with_refinement;
     structure_penalty
 }
 
@@ -1517,9 +1967,13 @@ fn compressive_utility_upper_bound(
     cost_of_node_all: &Vec<i32>,
     num_paths_to_node: &Vec<i32>,
 ) -> i32 {
-    match_locations.iter().map(|node|
-        cost_of_node_all[usize::from(*node)] 
-        - num_paths_to_node[usize::from(*node)] * COST_TERMINAL).sum::<i32>()
+    match_locations
+        .iter()
+        .map(|node| {
+            cost_of_node_all[usize::from(*node)]
+                - num_paths_to_node[usize::from(*node)] * COST_TERMINAL
+        })
+        .sum::<i32>()
 }
 
 /// calculates the total upper bound on compressive + noncompressive utility
@@ -1538,7 +1992,6 @@ fn compressive_utility_upper_bound(
 //     use_conflicts(pattern, utility_of_loc_once, compressive_utility, shared).util + noncompressive_utility_upper_bound(body_utility_with_refinement_lower_bound, &shared.cfg)
 // }
 
-
 /// This takes a partial invention and gives an upper bound on the maximum
 /// other_utility() that any completed offspring of this partial invention could have.
 #[inline(never)]
@@ -1546,27 +1999,40 @@ fn noncompressive_utility_upper_bound(
     body_utility_with_refinement_lower_bound: i32,
     cfg: &CompressionStepConfig,
 ) -> i32 {
-    if cfg.no_other_util { return 0; }
+    if cfg.no_other_util {
+        return 0;
+    }
     // safe bound: since structure_penalty is negative an upper bound is anything less negative or exact. Since
     // left_utility < body_utility we know that this will be a less negative bound.
-    let structure_penalty = - body_utility_with_refinement_lower_bound;
+    let structure_penalty = -body_utility_with_refinement_lower_bound;
     structure_penalty
 }
 
 #[inline(never)]
 fn compressive_utility(pattern: &Pattern, shared: &SharedData) -> UtilityCalculation {
-
     // * BASIC CALCULATION
     // Roughly speaking compressive utility is num_usages(invention) * size(invention), however there are a few extra
     // terms we need to take care of too.
 
     // get a list of (ivar,usages-1) filtering out things that are only used once, this will come in handy for adding multi-use utility later
-    let ivar_multiuses: Vec<(usize,i32)> = pattern.arg_choices.iter().map(|labelled|labelled.ivar).counts()
-        .iter().filter_map(|(ivar,count)| if *count > 1 { Some((*ivar, (*count-1) as i32)) } else { None }).collect();
+    let ivar_multiuses: Vec<(usize, i32)> = pattern
+        .arg_choices
+        .iter()
+        .map(|labelled| labelled.ivar)
+        .counts()
+        .iter()
+        .filter_map(|(ivar, count)| {
+            if *count > 1 {
+                Some((*ivar, (*count - 1) as i32))
+            } else {
+                None
+            }
+        })
+        .collect();
 
     // (parent,child) show up in here if they conflict
-    let mut refinement_conflicts: AHashSet<(Id,Id)> = Default::default();
-    for r in pattern.refinements.iter().filter_map(|r|r.as_ref()) {
+    let mut refinement_conflicts: AHashSet<(Id, Id)> = Default::default();
+    for r in pattern.refinements.iter().filter_map(|r| r.as_ref()) {
         for ancestor in r.iter() {
             for descendant in r.iter() {
                 if ancestor != descendant && is_descendant(*descendant, *ancestor, &shared.egraph) {
@@ -1579,72 +2045,110 @@ fn compressive_utility(pattern: &Pattern, shared: &SharedData) -> UtilityCalcula
     // it costs a tiny bit to apply the invention, for example (app (app inv0 x) y) incurs a cost
     // of COST_TERMINAL for the `inv0` primitive and 2 * COST_NONTERMINAL for the two `app`s.
     // Also an extra COST_NONTERMINAL for each argument that is refined (for the lambda).
-    let app_penalty = - (COST_TERMINAL + COST_NONTERMINAL * pattern.first_zid_of_ivar.len() as i32 + COST_NONTERMINAL * pattern.refinements.iter().map(|r|if let Some(refinements) = r {refinements.len() as i32} else {0}).sum::<i32>());
+    let app_penalty = -(COST_TERMINAL
+        + COST_NONTERMINAL * pattern.first_zid_of_ivar.len() as i32
+        + COST_NONTERMINAL
+            * pattern
+                .refinements
+                .iter()
+                .map(|r| {
+                    if let Some(refinements) = r {
+                        refinements.len() as i32
+                    } else {
+                        0
+                    }
+                })
+                .sum::<i32>());
 
+    let utility_of_loc_once: Vec<i32> = pattern
+        .match_locations
+        .iter()
+        .map(|loc| {
+            // println!("calculating util of {}", extract(*loc, &shared.egraph));
+            // compressivity of body (no refinement) minus slight penalty from the application
+            let base_utility = pattern.body_utility_no_refinement + app_penalty;
+            // println!("base {}", base_utility);
 
-    let utility_of_loc_once: Vec<i32> = pattern.match_locations.iter().map(|loc| {
-        // println!("calculating util of {}", extract(*loc, &shared.egraph));
-        // compressivity of body (no refinement) minus slight penalty from the application
-        let base_utility = pattern.body_utility_no_refinement + app_penalty;
-        // println!("base {}", base_utility);
+            // each use of the refined out arg gives a benefit equal to the size of the arg
+            let refinement_utility: i32 = pattern
+                .refinements
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| r.is_some())
+                .map(|(ivar, r)| {
+                    let refinements = r.as_ref().unwrap();
+                    // grab shifted arg
+                    let shifted_arg: Id =
+                        shared.arg_of_zid_node[pattern.first_zid_of_ivar[ivar]][loc].shifted_id;
+                    if let Some(uses_of_refinement) =
+                        shared.uses_of_shifted_arg_refinement.get(&shifted_arg)
+                    {
+                        return refinements
+                            .iter()
+                            .map(|refinement| {
+                                if let Some(uses) = uses_of_refinement.get(&refinement) {
+                                    // we subtract COST_TERMINAL because we need to leave behind a $i in place of it in the arg
+                                    let mut util = (*uses as i32)
+                                        * (shared.cost_of_node_once[usize::from(*refinement)]
+                                            - COST_TERMINAL);
+                                    // println!("gained util {} from {}", util, extract(*refinement, &shared.egraph));
+                                    for r in refinements.iter().filter(|r| {
+                                        refinement_conflicts.contains(&(*refinement, **r))
+                                    }) {
+                                        // we (an ancestor) conflicted with a descendant so we lose some of that descendants util
+                                        // todo: importantly this doesnt when a grandparent negates both a parent and a child...
+                                        // todo that would be necessary for 3+ refinements and would be closer to our full conflict resolution setup
+                                        assert!(refinements.len() < 3);
+                                        util -= (*uses as i32)
+                                            * (shared.cost_of_node_once[usize::from(*r)]
+                                                - COST_TERMINAL);
+                                    }
+                                    util
+                                } else {
+                                    0
+                                }
+                            })
+                            .sum::<i32>();
+                    }
+                    // if uses_of_shifted_arg_refinement lacks this shifted_arg then it must not have any refinements so we must not be getting any refinement gain here
+                    // likewise if the inner hashmap uses_of_shifted_arg_refinement[shifted_arg] lacks this refinement then we wont get any benefit
+                    0
+                })
+                .sum();
 
-        // each use of the refined out arg gives a benefit equal to the size of the arg
-        let refinement_utility: i32 = pattern.refinements.iter().enumerate().filter(|(_,r)| r.is_some()).map(|(ivar,r)| {
-            let refinements = r.as_ref().unwrap();
-            // grab shifted arg
-            let shifted_arg: Id = shared.arg_of_zid_node[pattern.first_zid_of_ivar[ivar]][loc].shifted_id;
-            if let Some(uses_of_refinement) =  shared.uses_of_shifted_arg_refinement.get(&shifted_arg) {
-                return refinements.iter().map(|refinement| {
-                    if let Some(uses) = uses_of_refinement.get(&refinement) {
-                        // we subtract COST_TERMINAL because we need to leave behind a $i in place of it in the arg
-                        let mut util = (*uses as i32) * (shared.cost_of_node_once[usize::from(*refinement)] - COST_TERMINAL);
-                        // println!("gained util {} from {}", util, extract(*refinement, &shared.egraph));
-                        for r in refinements.iter().filter(|r| refinement_conflicts.contains(&(*refinement,**r))) {
-                            // we (an ancestor) conflicted with a descendant so we lose some of that descendants util
-                            // todo: importantly this doesnt when a grandparent negates both a parent and a child... 
-                            // todo that would be necessary for 3+ refinements and would be closer to our full conflict resolution setup
-                            assert!(refinements.len() < 3);
-                            util -=  (*uses as i32) * (shared.cost_of_node_once[usize::from(*r)] - COST_TERMINAL);
-                        }
-                        util
-                    } else { 0 }
-                }).sum::<i32>()
+            // println!("refinement {}", refinement_utility);
+
+            // the bad refinement override: if there are any free ivars in the arg at this location (ignoring the refinement itself if there
+            // is one) then we can't apply this invention here so *total* util should be 0
+            for (ivar, zid) in pattern.first_zid_of_ivar.iter().enumerate() {
+                let shifted_arg = shared.arg_of_zid_node[*zid][loc].shifted_id;
+                if has_free_ivars(shifted_arg, &pattern.refinements[ivar], &shared.egraph) {
+                    return 0; // set whole util to 0 for this loc, causing an autoreject
+                }
             }
-            // if uses_of_shifted_arg_refinement lacks this shifted_arg then it must not have any refinements so we must not be getting any refinement gain here
-            // likewise if the inner hashmap uses_of_shifted_arg_refinement[shifted_arg] lacks this refinement then we wont get any benefit
-            0 
-        }).sum();
 
-        // println!("refinement {}", refinement_utility);
+            // for each extra usage of an argument, we gain the cost of that argument as
+            // extra utility. Note we use `first_zid_of_ivar` since it doesn't matter which
+            // of the zids we use as long as it corresponds to the right ivar
+            let multiuse_utility = ivar_multiuses
+                .iter()
+                .map(|(ivar, count)| {
+                    count * shared.arg_of_zid_node[pattern.first_zid_of_ivar[*ivar]][loc].cost
+                })
+                .sum::<i32>();
+            // println!("multiuse {}", multiuse_utility);
 
+            // multiply all this utility by the number of times this node shows up
+            base_utility + multiuse_utility + refinement_utility
+        })
+        .collect();
 
-        // the bad refinement override: if there are any free ivars in the arg at this location (ignoring the refinement itself if there
-        // is one) then we can't apply this invention here so *total* util should be 0
-        for (ivar,zid) in pattern.first_zid_of_ivar.iter().enumerate() {
-            let shifted_arg = shared.arg_of_zid_node[*zid][loc].shifted_id;
-            if has_free_ivars(shifted_arg, &pattern.refinements[ivar], &shared.egraph) {
-                return 0; // set whole util to 0 for this loc, causing an autoreject
-            }
-        }
-
-        // for each extra usage of an argument, we gain the cost of that argument as
-        // extra utility. Note we use `first_zid_of_ivar` since it doesn't matter which
-        // of the zids we use as long as it corresponds to the right ivar
-        let multiuse_utility = ivar_multiuses.iter().map(|(ivar,count)|
-            count * shared.arg_of_zid_node[pattern.first_zid_of_ivar[*ivar]][loc].cost
-        ).sum::<i32>();
-        // println!("multiuse {}", multiuse_utility);
-
-        // multiply all this utility by the number of times this node shows up
-        base_utility + multiuse_utility + refinement_utility
-        }).collect();
-
-
-    let compressive_utility: i32 = pattern.match_locations.iter()
+    let compressive_utility: i32 = pattern
+        .match_locations
+        .iter()
         .zip(utility_of_loc_once.iter())
-        .map(|(loc,utility)| utility * shared.num_paths_to_node[usize::from(*loc)])
+        .map(|(loc, utility)| utility * shared.num_paths_to_node[usize::from(*loc)])
         .sum();
-
 
     // assertion to make sure pattern.match_locations is sorted (for binary searching + bottom up iterating)
     // {
@@ -1656,20 +2160,35 @@ fn compressive_utility(pattern: &Pattern, shared: &SharedData) -> UtilityCalcula
     //         }));
     // }
 
-        // * ACCOUNTING FOR USE CONFLICTS:
-
+    // * ACCOUNTING FOR USE CONFLICTS:
 
     use_conflicts(pattern, utility_of_loc_once, compressive_utility, shared)
 }
 
 #[inline(never)]
-fn use_conflicts(pattern: &Pattern, utility_of_loc_once: Vec<i32>, compressive_utility: i32, shared: &SharedData) -> UtilityCalculation {
-
+fn use_conflicts(
+    pattern: &Pattern,
+    utility_of_loc_once: Vec<i32>,
+    compressive_utility: i32,
+    shared: &SharedData,
+) -> UtilityCalculation {
     // todo opt include holes too
     // zips and ivars
-    let zips: Vec<(Zip,Option<usize>)> = pattern.arg_choices.iter()
-        .map(|labelled_zid| (shared.zip_of_zid[labelled_zid.zid].clone(),Some(labelled_zid.ivar)))
-        .chain(pattern.holes.iter().map(|zid| (shared.zip_of_zid[*zid].clone(), None)))
+    let zips: Vec<(Zip, Option<usize>)> = pattern
+        .arg_choices
+        .iter()
+        .map(|labelled_zid| {
+            (
+                shared.zip_of_zid[labelled_zid.zid].clone(),
+                Some(labelled_zid.ivar),
+            )
+        })
+        .chain(
+            pattern
+                .holes
+                .iter()
+                .map(|zid| (shared.zip_of_zid[*zid].clone(), None)),
+        )
         .collect();
     // if holes {
     //     zips.extend(pattern.holes.iter().map(|zid| (shared.zip_of_zid[zid].clone(),labelled_zid.ivar)))
@@ -1677,53 +2196,61 @@ fn use_conflicts(pattern: &Pattern, utility_of_loc_once: Vec<i32>, compressive_u
 
     // the idea here is we want the fast-path to be the case where no conflicts happen. If no conflicts happen, there should be
     // zero heap allocations in this whole section! Since empty vecs and hashmaps dont cause allocations yet.
-    let mut corrected_utils: AHashMap<Id,CorrectedUtil> = Default::default();
+    let mut corrected_utils: AHashMap<Id, CorrectedUtil> = Default::default();
     let mut global_correction = 0; // this is going to get added to the compressive_utility at the end to correct for use-conflicts
 
     // bottom up traversal since we assume match_locations is sorted
-    for (loc_idx,loc) in pattern.match_locations.iter().enumerate() {
+    for (loc_idx, loc) in pattern.match_locations.iter().enumerate() {
         // get all the nodes this could conflict with (by idx within `locs` not by id)
-        let conflict_idxs: AHashSet<(Id,usize)> = get_conflicts(&zips, loc, shared, pattern);
+        let conflict_idxs: AHashSet<(Id, usize)> = get_conflicts(&zips, loc, shared, pattern);
 
         // now we basically record how much we would affect global utility by if we accept vs reject vs choose the best of those options.
         // and recording this will let us change our mind later if we decide to force-reject something
 
         // if we reject using the invention at this node, we just lose its utility
-        let reject = - utility_of_loc_once[loc_idx];
+        let reject = -utility_of_loc_once[loc_idx];
 
         // Rare case: when utility_of_loc_once is <=0, then reject is >=0 and of course we should do it
         // (it benefits us or rather brings us back to 0, and leaves maximal flexibility for other things to be accepted/rejected).
         // and theres nothing else we need to account for here.
         if reject >= 0 {
             global_correction += reject * shared.num_paths_to_node[usize::from(*loc)];
-            corrected_utils.insert(*loc, CorrectedUtil {
-                accept: false, // we rejected
-                best_util_correction: reject, // we rejected
-                util_change_to_reject: 0 // we rejected so no change to reject
-            });
-            continue
+            corrected_utils.insert(
+                *loc,
+                CorrectedUtil {
+                    accept: false,                // we rejected
+                    best_util_correction: reject, // we rejected
+                    util_change_to_reject: 0,     // we rejected so no change to reject
+                },
+            );
+            continue;
         }
 
         // common case: no conflicts
         // (this has to come AFTER the possible forced rejection)
-        if conflict_idxs.is_empty() { continue; }
-        
+        if conflict_idxs.is_empty() {
+            continue;
+        }
         // if we accept using the invention at this node everywhere, we lose the util of the difference of the best choice of each descendant vs the reject choice
         // so for example if all the conflicts had chosen to Reject anyways then this would be 0 (optimal)
         // but if some chose to Accept then our Accept correction will include the difference caused by forcing them to reject
         // This is easiest to understand if you think of reject as "the effect on global util of rejecting at a single location"
         // and likewise for accept and best.
-        let accept = conflict_idxs.iter()
-            .map(|(id,idx)|
-                corrected_utils.get(id).map(|x|x.util_change_to_reject)
-                // if it's not in corrected_utils, it must have had no conflicts so we must be switching from accept to reject with no other side effects
-                // so we do (reject - accept) = (- util(idx) - 0) = - util(idx)
-                // where accept was 0 since it caused no conflicts
-                .unwrap_or_else(|| - utility_of_loc_once[*idx]) 
-            ).sum();
+        let accept = conflict_idxs
+            .iter()
+            .map(|(id, idx)| {
+                corrected_utils
+                    .get(id)
+                    .map(|x| x.util_change_to_reject)
+                    // if it's not in corrected_utils, it must have had no conflicts so we must be switching from accept to reject with no other side effects
+                    // so we do (reject - accept) = (- util(idx) - 0) = - util(idx)
+                    // where accept was 0 since it caused no conflicts
+                    .unwrap_or_else(|| -utility_of_loc_once[*idx])
+            })
+            .sum();
 
         // lets accept the less negative of the options
-        let best_util_correction = std::cmp::max(reject,accept);
+        let best_util_correction = std::cmp::max(reject, accept);
 
         // update global correction with this applied to all our nodes (note that the same choice makes sense for all nodes
         // from the point of view of this being the top of the tree - it's our parents job to use change_to_reject if they
@@ -1732,16 +2259,19 @@ fn use_conflicts(pattern: &Pattern, utility_of_loc_once: Vec<i32>, compressive_u
 
         let util_change_to_reject = reject - best_util_correction;
 
-        corrected_utils.insert(*loc, CorrectedUtil {
-            accept: best_util_correction == accept,
-            best_util_correction,
-            util_change_to_reject
-        });
+        corrected_utils.insert(
+            *loc,
+            CorrectedUtil {
+                accept: best_util_correction == accept,
+                best_util_correction,
+                util_change_to_reject,
+            },
+        );
 
         // Involved example:
         // A -> B -> C  (ie A conflicts with B conflicts with C; and A is the parent)
         // and also A -> C
-        // 
+        //
         // First we calculate C.accept C.reject
         // B.reject as - util(B)
         // B.accept as (C.reject - C.best)
@@ -1760,56 +2290,71 @@ fn use_conflicts(pattern: &Pattern, utility_of_loc_once: Vec<i32>, compressive_u
         //          = (B.reject - B.accept) + (C.reject - C.best)
         //          = (B.reject - (C.reject - C.best)) + (C.reject - C.best)
         //          = B.reject = - util(B)
-        // which is good because we've already modified the global util to incorporate C rejection when we decided that B.best 
+        // which is good because we've already modified the global util to incorporate C rejection when we decided that B.best
         // was B.accept, so it's good that the C terms cancel out here. You can think of what happened like this: we force-reject C
         // which creates a (C.reject - C.best) term, but then we force reject B and since B.best was B.accept which involved C rejection,
         // we get another (C.reject - C.best) term that cancels out the first
         //
         // if B.best was B.accept, then (B.reject - B.best) = (B.reject - B.accept) = (B.reject - (C.reject - C.best))
-
     }
 
-    UtilityCalculation { util: (compressive_utility + global_correction), corrected_utils}
+    UtilityCalculation {
+        util: (compressive_utility + global_correction),
+        corrected_utils,
+    }
 }
 
 #[inline(never)]
-fn get_conflicts(zips: &Vec<(Vec<ZNode>, Option<usize>)>, loc: &Id, shared: &SharedData, pattern: &Pattern) -> AHashSet<(Id, usize)> {
+fn get_conflicts(
+    zips: &Vec<(Vec<ZNode>, Option<usize>)>,
+    loc: &Id,
+    shared: &SharedData,
+    pattern: &Pattern,
+) -> AHashSet<(Id, usize)> {
     let mut conflict_idxs = AHashSet::new();
-    for (zip,ivar) in zips.iter().filter(|(zip,_)| !zip.is_empty()) {
+    for (zip, ivar) in zips.iter().filter(|(zip, _)| !zip.is_empty()) {
         let mut id = loc;
         // for all except the last node in the zipper, push the childs location on as a potential conflict
-        for znode in zip[..zip.len()-1].iter() {
+        for znode in zip[..zip.len() - 1].iter() {
             // step one deeper
             id = match (znode, &shared.node_of_id[usize::from(*id)]) {
                 (ZNode::Body, Lambda::Lam([b])) => b,
-                (ZNode::Func, Lambda::App([f,_])) => f,
-                (ZNode::Arg, Lambda::App([_,x])) => x,
-                _ => unreachable!()
+                (ZNode::Func, Lambda::App([f, _])) => f,
+                (ZNode::Arg, Lambda::App([_, x])) => x,
+                _ => unreachable!(),
             };
             // if its also a location, push it to the conflicts list (do NOT dedup)
             if let Ok(idx) = pattern.match_locations.binary_search(id) {
-                conflict_idxs.insert((*id,idx));
+                conflict_idxs.insert((*id, idx));
             }
         }
         // if this is a refinement, push every descendant of the unshifted argument including it itself as a potential conflict
         if let Some(ivar) = ivar {
             if pattern.refinements[*ivar].is_some() {
                 #[inline(never)]
-                fn helper(id: Id, shared: &SharedData, conflict_idxs: &mut AHashSet<(Id,usize)>, pattern: &Pattern) {
+                fn helper(
+                    id: Id,
+                    shared: &SharedData,
+                    conflict_idxs: &mut AHashSet<(Id, usize)>,
+                    pattern: &Pattern,
+                ) {
                     if let Ok(idx) = pattern.match_locations.binary_search(&id) {
-                        conflict_idxs.insert((id,idx));
+                        conflict_idxs.insert((id, idx));
                     }
                     match &shared.node_of_id[usize::from(id)] {
-                        Lambda::Lam([b]) => {helper(*b, shared, conflict_idxs, pattern);},
-                        Lambda::App([f,x]) => {
+                        Lambda::Lam([b]) => {
+                            helper(*b, shared, conflict_idxs, pattern);
+                        }
+                        Lambda::App([f, x]) => {
                             helper(*f, shared, conflict_idxs, pattern);
                             helper(*x, shared, conflict_idxs, pattern);
                         }
-                        Lambda::Prim(_) | Lambda::Var(_) | Lambda::IVar(_) => {},
-                        _ => unreachable!()
+                        Lambda::Prim(_) | Lambda::Var(_) | Lambda::IVar(_) => {}
+                        _ => unreachable!(),
                     }
                 }
-                let unshifted_arg: Id = shared.arg_of_zid_node[pattern.first_zid_of_ivar[*ivar]][loc].unshifted_id;
+                let unshifted_arg: Id =
+                    shared.arg_of_zid_node[pattern.first_zid_of_ivar[*ivar]][loc].unshifted_id;
                 helper(unshifted_arg, shared, &mut conflict_idxs, pattern);
             }
         }
@@ -1821,7 +2366,7 @@ fn get_conflicts(zips: &Vec<(Vec<ZNode>, Option<usize>)>, loc: &Id, shared: &Sha
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UtilityCalculation {
     pub util: i32,
-    pub corrected_utils: AHashMap<Id,CorrectedUtil>,
+    pub corrected_utils: AHashMap<Id, CorrectedUtil>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1831,24 +2376,25 @@ pub struct CorrectedUtil {
     pub util_change_to_reject: i32, // if accept=false this is 0 otherwise it's the difference in utility between accept and reject. Always <= 0.
 }
 
-
-
 /// Multistep compression. See `compression_step` if you'd just like to do a single step of compression.
 pub fn compression(
     programs_expr: &Expr,
     iterations: usize,
     cfg: &CompressionStepConfig,
     tasks: &Vec<String>,
-    num_prior_inventions: usize,
+    prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
 ) -> Vec<CompressionStepResult> {
-
+    let num_prior_inventions = prev_dc_inv_to_inv_strs.len();
     let mut rewritten: Expr = programs_expr.clone();
     let mut step_results: Vec<CompressionStepResult> = Default::default();
 
     let tstart = std::time::Instant::now();
 
     for i in 0..iterations {
-        println!("{}",format!("\n=======Iteration {}=======",i).blue().bold());
+        println!(
+            "{}",
+            format!("\n=======Iteration {}=======", i).blue().bold()
+        );
         let inv_name = format!("fn_{}", num_prior_inventions + step_results.len());
 
         // call actual compression
@@ -1857,7 +2403,9 @@ pub fn compression(
             &inv_name,
             &cfg,
             &step_results,
-            tasks);
+            tasks,
+            prev_dc_inv_to_inv_strs,
+        );
 
         if !res.is_empty() {
             // rewrite with the invention
@@ -1866,31 +2414,49 @@ pub fn compression(
             println!("Chose Invention {}: {}", res.inv.name, res);
             step_results.push(res);
         } else {
-            println!("No inventions found at iteration {}",i);
+            println!("No inventions found at iteration {}", i);
             break;
         }
     }
 
     if cfg.dreamcoder_drop_last {
-        println!("{}",format!("{}","[--dreamcoder-drop-last] dropping final invention".yellow().bold()));
+        println!(
+            "{}",
+            format!(
+                "{}",
+                "[--dreamcoder-drop-last] dropping final invention"
+                    .yellow()
+                    .bold()
+            )
+        );
         step_results.pop();
     }
 
-    println!("{}","\n=======Compression Summary=======".blue().bold());
+    println!("{}", "\n=======Compression Summary=======".blue().bold());
     println!("Found {} inventions", step_results.len());
-    println!("Cost Improvement: ({:.2}x better) {} -> {}", compression_factor(programs_expr,&rewritten), programs_expr.cost(), rewritten.cost());
+    println!(
+        "Cost Improvement: ({:.2}x better) {} -> {}",
+        compression_factor(programs_expr, &rewritten),
+        programs_expr.cost(),
+        rewritten.cost()
+    );
     for i in 0..step_results.len() {
         let res = &step_results[i];
-        println!("{} ({:.2}x wrt orig): {}" ,res.inv.name.clone().blue(), compression_factor(programs_expr, &res.rewritten), res);
+        println!(
+            "{} ({:.2}x wrt orig): {}",
+            res.inv.name.clone().blue(),
+            compression_factor(programs_expr, &res.rewritten),
+            res
+        );
     }
     println!("Time: {}ms", tstart.elapsed().as_millis());
-    if cfg.follow_track && !(
-        cfg.no_opt_free_vars
-        && cfg.no_opt_single_task
-        && cfg.no_opt_upper_bound
-        && cfg.no_opt_force_multiuse
-        && cfg.no_opt_useless_abstract
-        && cfg.no_opt_arity_zero)
+    if cfg.follow_track
+        && !(cfg.no_opt_free_vars
+            && cfg.no_opt_single_task
+            && cfg.no_opt_upper_bound
+            && cfg.no_opt_force_multiuse
+            && cfg.no_opt_useless_abstract
+            && cfg.no_opt_arity_zero)
     {
         println!("{} you often want to run --follow-track with --no-opt otherwise your target may get pruned", "[WARNING]".yellow());
     }
@@ -1906,8 +2472,8 @@ pub fn compression_step(
     cfg: &CompressionStepConfig,
     past_invs: &Vec<CompressionStepResult>, // past inventions we've found
     tasks: &Vec<String>,
+    prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
 ) -> Vec<CompressionStepResult> {
-
     let tstart_total = std::time::Instant::now();
     let tstart_prep = std::time::Instant::now();
     let mut tstart = std::time::Instant::now();
@@ -1921,16 +2487,29 @@ pub fn compression_step(
     println!("set up egraph: {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
-    let roots: Vec<Id> = egraph[programs_node].nodes[0].children().iter().cloned().collect();
+    let roots: Vec<Id> = egraph[programs_node].nodes[0]
+        .children()
+        .iter()
+        .cloned()
+        .collect();
 
     // all nodes in child-first order except for the Programs node
-    let mut treenodes: Vec<Id> = topological_ordering(programs_node,&egraph);
-    assert!(treenodes.iter().enumerate().all(|(i,node)| i == usize::from(*node)));
+    let mut treenodes: Vec<Id> = topological_ordering(programs_node, &egraph);
+    assert!(treenodes
+        .iter()
+        .enumerate()
+        .all(|(i, node)| i == usize::from(*node)));
     // assert_eq!(treenodes.iter().map(|n| usize::from(*n)).collect::<Vec<_>>(), (0..treenodes.len()).collect::<Vec<_>>());
-    let node_of_id: Vec<Lambda> = treenodes.iter().map(|node| egraph[*node].nodes[0].clone()).collect();
+    let node_of_id: Vec<Lambda> = treenodes
+        .iter()
+        .map(|node| egraph[*node].nodes[0].clone())
+        .collect();
     treenodes.retain(|id| *id != programs_node);
 
-    println!("got roots, treenodes, and cloned egraph contents: {:?}ms", tstart.elapsed().as_millis());
+    println!(
+        "got roots, treenodes, and cloned egraph contents: {:?}ms",
+        tstart.elapsed().as_millis()
+    );
     tstart = std::time::Instant::now();
 
     // populate num_paths_to_node so we know how many different parts of the programs tree
@@ -1940,40 +2519,60 @@ pub fn compression_step(
     println!("num_paths_to_node(): {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
-    let tasks_of_node: Vec<AHashSet<usize>> = associate_tasks(programs_node, &egraph, &treenodes, tasks);
+    let tasks_of_node: Vec<AHashSet<usize>> =
+        associate_tasks(programs_node, &egraph, &treenodes, tasks);
 
     println!("associate_tasks(): {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
     // cost of a single usage of a node (same as inventionless_cost)
-    let cost_of_node_once: Vec<i32> = treenodes.iter().map(|node| egraph[*node].data.inventionless_cost).collect();
+    let cost_of_node_once: Vec<i32> = treenodes
+        .iter()
+        .map(|node| egraph[*node].data.inventionless_cost)
+        .collect();
     // cost of a single usage times number of paths to node
-    let cost_of_node_all: Vec<i32> = treenodes.iter().map(|node| cost_of_node_once[usize::from(*node)] * num_paths_to_node[usize::from(*node)]).collect();
+    let cost_of_node_all: Vec<i32> = treenodes
+        .iter()
+        .map(|node| cost_of_node_once[usize::from(*node)] * num_paths_to_node[usize::from(*node)])
+        .collect();
 
-    let free_vars_of_node: Vec<AHashSet<i32>> = treenodes.iter().map(|node| egraph[*node].data.free_vars.clone()).collect();
+    let free_vars_of_node: Vec<AHashSet<i32>> = treenodes
+        .iter()
+        .map(|node| egraph[*node].data.free_vars.clone())
+        .collect();
 
     println!("cost_of_node structs: {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
 
-    let (zid_of_zip,
+    let (
+        zid_of_zip,
         zip_of_zid,
         arg_of_zid_node,
         zids_of_node,
         extensions_of_zid,
-        uses_of_shifted_arg_refinement) = get_zippers(&treenodes, &cost_of_node_once, cfg.no_cache, &mut egraph, cfg);
-    
+        uses_of_shifted_arg_refinement,
+    ) = get_zippers(
+        &treenodes,
+        &cost_of_node_once,
+        cfg.no_cache,
+        &mut egraph,
+        cfg,
+    );
     println!("get_zippers(): {:?}ms", tstart.elapsed().as_millis());
     tstart = std::time::Instant::now();
-    
     println!("{} zips", zip_of_zid.len());
     println!("arg_of_zid_node size: {}", arg_of_zid_node.len());
 
     // set up tracking if any
-    let tracking: Option<Tracking> = cfg.track.as_ref().map(|s|{
+    let tracking: Option<Tracking> = cfg.track.as_ref().map(|s| {
         let expr: Expr = s.parse().unwrap();
         let zids_of_ivar = zids_of_ivar_of_expr(&expr, &zid_of_zip);
         let refined = cfg.track_refined.as_ref().map(|s| s.parse().unwrap());
-        Tracking { expr, zids_of_ivar, refined }
+        Tracking {
+            expr,
+            zids_of_ivar,
+            refined,
+        }
     });
 
     println!("Tracking setup: {:?}ms", tstart.elapsed().as_millis());
@@ -1983,22 +2582,25 @@ pub fn compression_step(
     tstart = std::time::Instant::now();
 
     // define all the important data structures for compression
-    let mut donelist: Vec<FinishedPattern> = Default::default(); // completed inventions will go here    
+    let mut donelist: Vec<FinishedPattern> = Default::default(); // completed inventions will go here
 
     // arity 0 inventions
     if !cfg.no_opt_arity_zero {
         for node in treenodes.iter() {
-
             // check for free vars: inventions with free vars in the body are not well-defined functions
             // and should thus be discarded
             if !cfg.no_opt_free_vars && !egraph[*node].data.free_vars.is_empty() {
-                if !cfg.no_stats { stats.free_vars_fired += 1; };
+                if !cfg.no_stats {
+                    stats.free_vars_fired += 1;
+                };
                 continue;
             }
 
             // check whether this invention is useful in > 1 task
             if !cfg.no_opt_single_task && tasks_of_node[usize::from(*node)].len() < 2 {
-                if !cfg.no_stats { stats.single_task_fired += 1; };
+                if !cfg.no_stats {
+                    stats.single_task_fired += 1;
+                };
                 continue;
             }
             // Note that "single use" pruning is intentionally not done here,
@@ -2009,9 +2611,13 @@ pub fn compression_step(
             let body_utility_no_refinement = cost_of_node_once[usize::from(*node)];
             let refinement_body_utility = 0;
             // compressive_utility for arity-0 is cost_of_node_all[node] minus the penalty of using the new prim
-            let compressive_utility = cost_of_node_all[usize::from(*node)] - num_paths_to_node[usize::from(*node)] * COST_TERMINAL;
-            let utility = compressive_utility + noncompressive_utility(body_utility_no_refinement + refinement_body_utility, cfg);
-            if utility <= 0 { continue; }
+            let compressive_utility = cost_of_node_all[usize::from(*node)]
+                - num_paths_to_node[usize::from(*node)] * COST_TERMINAL;
+            let utility = compressive_utility
+                + noncompressive_utility(body_utility_no_refinement + refinement_body_utility, cfg);
+            if utility <= 0 {
+                continue;
+            }
 
             let pattern = Pattern {
                 holes: vec![],
@@ -2028,9 +2634,12 @@ pub fn compression_step(
                 pattern,
                 utility,
                 compressive_utility,
-                util_calc: UtilityCalculation { util: compressive_utility, corrected_utils: Default::default()},
+                util_calc: UtilityCalculation {
+                    util: compressive_utility,
+                    corrected_utils: Default::default(),
+                },
                 arity: 0,
-                usages: num_paths_to_node[usize::from(*node)]
+                usages: num_paths_to_node[usize::from(*node)],
             };
             donelist.push(finished_pattern);
         }
@@ -2041,7 +2650,14 @@ pub fn compression_step(
 
     println!("got {} arity zero inventions", donelist.len());
 
-    let crit = CriticalMultithreadData::new(donelist, &treenodes, &cost_of_node_all, &num_paths_to_node, &egraph, &cfg);
+    let crit = CriticalMultithreadData::new(
+        donelist,
+        &treenodes,
+        &cost_of_node_all,
+        &num_paths_to_node,
+        &egraph,
+        &cfg,
+    );
     let shared = Arc::new(SharedData {
         crit: Mutex::new(crit),
         arg_of_zid_node,
@@ -2074,7 +2690,12 @@ pub fn compression_step(
         if !crit.deref_mut().donelist.is_empty() {
             let best_util = crit.deref_mut().donelist.first().unwrap().utility;
             let best_expr: String = crit.deref_mut().donelist.first().unwrap().info(&shared);
-            println!("{} @ step=0 util={} for {}", "[new best utility]".blue(), best_util, best_expr);
+            println!(
+                "{} @ step=0 util={} for {}",
+                "[new best utility]".blue(),
+                best_util,
+                best_expr
+            );
         }
     }
 
@@ -2095,7 +2716,6 @@ pub fn compression_step(
         for _ in 0..cfg.threads {
             // clone the Arcs to have copies for this thread
             let shared = Arc::clone(&shared);
-            
             // launch thread to just call stitch_search()
             handles.push(thread::spawn(move || {
                 stitch_search(shared);
@@ -2108,8 +2728,10 @@ pub fn compression_step(
     }
 
     println!("TOTAL SEARCH: {:?}ms", tstart.elapsed().as_millis());
-    println!("TOTAL PREP + SEARCH: {:?}ms", tstart_total.elapsed().as_millis());
-
+    println!(
+        "TOTAL PREP + SEARCH: {:?}ms",
+        tstart_total.elapsed().as_millis()
+    );
 
     tstart = std::time::Instant::now();
 
@@ -2125,24 +2747,50 @@ pub fn compression_step(
     let donelist: Vec<FinishedPattern> = shared.crit.lock().deref_mut().donelist.clone();
 
     if cfg.dreamcoder_comparison {
-        println!("Timing point 1 (from the start of compression_step to final donelist): {:?}ms", tstart_total.elapsed().as_millis());
-        println!("Timing Comparison Point A (search) (millis): {}", tstart_total.elapsed().as_millis());
+        println!(
+            "Timing point 1 (from the start of compression_step to final donelist): {:?}ms",
+            tstart_total.elapsed().as_millis()
+        );
+        println!(
+            "Timing Comparison Point A (search) (millis): {}",
+            tstart_total.elapsed().as_millis()
+        );
         let tstart_rewrite = std::time::Instant::now();
         rewrite_fast(&donelist[0], &shared, new_inv_name);
-        println!("Timing point 2 (rewriting the candidate): {:?}ms", tstart_rewrite.elapsed().as_millis());
-        println!("Timing Comparison Point B (search+rewrite) (millis): {}", tstart_total.elapsed().as_millis());
+        println!(
+            "Timing point 2 (rewriting the candidate): {:?}ms",
+            tstart_rewrite.elapsed().as_millis()
+        );
+        println!(
+            "Timing Comparison Point B (search+rewrite) (millis): {}",
+            tstart_total.elapsed().as_millis()
+        );
     }
 
     let mut results: Vec<CompressionStepResult> = vec![];
 
     // construct CompressionStepResults and print some info about them)
     println!("Cost before: {}", shared.init_cost);
-    for (i,done) in donelist.iter().enumerate() {
-        let res = CompressionStepResult::new(done.clone(), new_inv_name, &mut shared, past_invs);
+    for (i, done) in donelist.iter().enumerate() {
+        let res = CompressionStepResult::new(
+            done.clone(),
+            new_inv_name,
+            &mut shared,
+            past_invs,
+            prev_dc_inv_to_inv_strs,
+        );
 
         println!("{}: {}", i, res);
         if cfg.show_rewritten {
-            println!("rewritten:\n{}", res.rewritten.split_programs().iter().map(|p|p.to_string()).collect::<Vec<_>>().join("\n"));
+            println!(
+                "rewritten:\n{}",
+                res.rewritten
+                    .split_programs()
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
         }
         results.push(res);
     }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1,46 +1,81 @@
-use std::iter::{repeat};
-use std::path::Path;
-use std::fs::File;
 use clap::ArgEnum;
 use serde::Serialize;
 use serde_json::de::from_reader;
+use std::fs::File;
+use std::iter::repeat;
+use std::path::Path;
 
 #[derive(Debug, Clone, ArgEnum, Serialize)]
 pub enum InputFormat {
     Dreamcoder,
-    ProgramsList
+    ProgramsList,
+}
+
+pub struct Input {
+    pub programs: Vec<String>,                          // Program strings.
+    pub tasks: Vec<String>,                             // Task names.
+    pub prev_dc_inv_to_inv_strs: Vec<(String, String)>, // Vec of  [#(dreamcoder invention), fn_i] tuples for any existing inventions in the DSL.
 }
 
 impl InputFormat {
-    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<(Vec<String>, Vec<String>, usize), String> {
+    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<(Input), String> {
         match self {
             &InputFormat::Dreamcoder => {
                 // read dreamcoder format
-                let json: serde_json::Value = from_reader(File::open(path).expect("file not found")).expect("json deserializing error");
-                let frontiers = json["frontiers"].as_array().unwrap_or_else(||panic!("json parse error, are you sure you wanted format {:?}?", self));
-                let mut dc_invs: Vec<String> = json["DSL"]["productions"].as_array().unwrap().iter().map(|prod|prod["expression"].as_str().unwrap().to_string())
+                let json: serde_json::Value =
+                    from_reader(File::open(path).expect("file not found"))
+                        .expect("json deserializing error");
+                let frontiers = json["frontiers"].as_array().unwrap_or_else(|| {
+                    panic!(
+                        "json parse error, are you sure you wanted format {:?}?",
+                        self
+                    )
+                });
+                let mut dc_invs: Vec<String> = json["DSL"]["productions"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|prod| prod["expression"].as_str().unwrap().to_string())
                     .filter(|s| s.starts_with("#"))
                     .collect();
                 dc_invs.sort_by_key(|s| s.len()); // increasing length so inventions that build on earlier ones come later
-                let inv_dc_strs: Vec<(String,String)> = dc_invs.into_iter().enumerate()
-                    .map(|(i,dc_str)| (format!("fn_{}",i),dc_str)).collect();
-                let num_prior_inventions: usize = inv_dc_strs.len();
+                let inv_dc_strs: Vec<(String, String)> = dc_invs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, dc_str)| (format!("fn_{}", i), dc_str))
+                    .collect();
                 let mut programs: Vec<String> = Vec::default();
                 let mut tasks: Vec<String> = Vec::default();
-                for (i,frontier) in frontiers.into_iter().enumerate() {
-                    let programs_in_frontier: Vec<String> = frontier["programs"].as_array().unwrap().iter().map(|p|p["program"].as_str().unwrap().to_string())
-                        .map(|p| inv_dc_strs.iter().rev().fold(p, |p, s| p.replace(&s.1, &s.0))) // replace #(lambda ...) with fn_2 etc. Start with highest numbered fn to avoid mangling bodies of other fns.
-                        .map(|p| p.replace("(lambda ","(lam ")).collect();
+                for (i, frontier) in frontiers.into_iter().enumerate() {
+                    let programs_in_frontier: Vec<String> = frontier["programs"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|p| p["program"].as_str().unwrap().to_string())
+                        .map(|p| {
+                            inv_dc_strs
+                                .iter()
+                                .rev()
+                                .fold(p, |p, s| p.replace(&s.1, &s.0))
+                        }) // replace #(lambda ...) with fn_2 etc. Start with highest numbered fn to avoid mangling bodies of other fns.
+                        .map(|p| p.replace("(lambda ", "(lam "))
+                        .collect();
                     assert!(!programs_in_frontier.iter().any(|p| p.contains("#")));
-                    let task: String = match frontier["task"].as_str(){
+                    let task: String = match frontier["task"].as_str() {
                         Some(name) => name.to_string(),
-                        None => i.to_string()
+                        None => i.to_string(),
                     };
-                    let task_repeated: Vec<String> = repeat(task).take(programs_in_frontier.len()).collect();
+                    let task_repeated: Vec<String> =
+                        repeat(task).take(programs_in_frontier.len()).collect();
                     programs.extend(programs_in_frontier);
                     tasks.extend(task_repeated);
                 }
-                Ok((programs, tasks, num_prior_inventions))
+                let input = Input {
+                    programs,
+                    tasks,
+                    prev_dc_inv_to_inv_strs: inv_dc_strs,
+                };
+                Ok(input)
             }
             &InputFormat::ProgramsList => {
                 let programs: Vec<String> = from_reader(File::open(path).map_err(|e| format!("file not found, error code {:?}", e))?).map_err(|e| format!("json parser error, are you sure you wanted format {:?}? Error code was {:?}", self, e))?;
@@ -50,11 +85,20 @@ impl InputFormat {
                     tasks.push(task_num.to_string());
                     task_num += 1;
                 }
-                let mut  num_prior_inventions = 0;
-                while programs.iter().any(|p| p.contains(&format!("fn_{}",num_prior_inventions))) {
+                let mut num_prior_inventions = 0;
+                while programs
+                    .iter()
+                    .any(|p| p.contains(&format!("fn_{}", num_prior_inventions)))
+                {
                     num_prior_inventions += 1;
                 }
-                Ok((programs, tasks, num_prior_inventions))
+
+                let input = Input {
+                    programs,
+                    tasks,
+                    prev_dc_inv_to_inv_strs: Vec::new(),
+                };
+                Ok(input)
             }
         }
     }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1,6 +1,7 @@
 use clap::ArgEnum;
 use serde::Serialize;
 use serde_json::de::from_reader;
+use std::collections::HashMap;
 use std::fs::File;
 use std::iter::repeat;
 use std::path::Path;
@@ -13,7 +14,7 @@ pub enum InputFormat {
 
 pub struct Input {
     pub programs: Vec<String>,                          // Program strings.
-    pub tasks: Vec<String>,                             // Task names.
+    pub tasks: Vec<String>, // Task names for each corresponding program string.
     pub prev_dc_inv_to_inv_strs: Vec<(String, String)>, // Vec of  [#(dreamcoder invention), fn_i] tuples for any existing inventions in the DSL.
 }
 
@@ -42,7 +43,7 @@ impl InputFormat {
                 let inv_dc_strs: Vec<(String, String)> = dc_invs
                     .into_iter()
                     .enumerate()
-                    .map(|(i, dc_str)| (format!("fn_{}", i), dc_str))
+                    .map(|(i, dc_str)| (format!("previous_dc_inv_{}", i), dc_str)) // Use a different naming prefix to avoid conflict with NEW inventions.
                     .collect();
                 let mut programs: Vec<String> = Vec::default();
                 let mut tasks: Vec<String> = Vec::default();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,8 @@
 use crate::*;
-use sexp::{Sexp,Atom};
+use ahash::AHashMap;
+use sexp::{Atom, Sexp};
 use std::fmt::Debug;
-use ahash::{AHashMap};
 use std::hash::Hash;
-
 
 /// Uncurries an s expression. For example: (app (app foo x) y) -> (foo x y)
 /// panics if sexp is already uncurried.
@@ -14,63 +13,56 @@ pub fn uncurry_sexp(e: &Sexp) -> Sexp {
             // recurse on children
             let uncurried_children: Vec<Sexp> = orig_list.iter().map(|e| uncurry_sexp(e)).collect();
             match uncurried_children[0].to_string().as_str() {
-                "lam" => {
-                    Sexp::List(uncurried_children)
-                },
-                "app" =>  {
+                "lam" => Sexp::List(uncurried_children),
+                "app" => {
                     // (app (app foo x) y) -> (foo x y)
                     assert_eq!(uncurried_children.len(), 3);
 
                     // see if `f` is also an app in which case we'll have to flatten
                     let has_inner_app = if let Sexp::List(innerlist) = &orig_list[1] {
                         innerlist[0].to_string().as_str() == "app"
-                    } else { false };
+                    } else {
+                        false
+                    };
 
                     let f = uncurried_children[1].clone();
                     let x = uncurried_children[2].clone();
-                    
                     let mut res = vec![];
 
                     if has_inner_app {
                         match f {
-                            Sexp::List(list) => { res.extend(list) }
-                            _ => panic!("expected list, got {}", f)
+                            Sexp::List(list) => res.extend(list),
+                            _ => panic!("expected list, got {}", f),
                         }
                     } else {
                         res.push(f);
                     }
                     res.push(x);
                     Sexp::List(res)
-                },
-                "programs" => {
-                    Sexp::List(uncurried_children)
                 }
+                "programs" => Sexp::List(uncurried_children),
                 _ => {
-                    panic!("not curried {}",e);
+                    panic!("not curried {}", e);
                 }
             }
-        },
-        Sexp::Atom(atom) => Sexp::Atom(atom.clone())
+        }
+        Sexp::Atom(atom) => Sexp::Atom(atom.clone()),
     }
 }
 
 /// Currys an s expression. For example: (foo x y) -> (app (app foo x) y)
 /// panics if sexp is already curried.
 pub fn curry_sexp(e: &Sexp) -> Sexp {
-    let app:Sexp = Sexp::Atom(Atom::S("app".into()));
+    let app: Sexp = Sexp::Atom(Atom::S("app".into()));
     match e {
         Sexp::List(list) => {
             assert!(list.len() > 1);
             // recurse on children
             let list: Vec<Sexp> = list.iter().map(|e| curry_sexp(e)).collect();
             match list[0].to_string().as_str() {
-                "lam" => {
-                    Sexp::List(list)
-                },
-                "app" => panic!("already curried: {}",e),
-                "programs" => {
-                    Sexp::List(list)
-                }
+                "lam" => Sexp::List(list),
+                "app" => panic!("already curried: {}", e),
+                "programs" => Sexp::List(list),
                 _ => {
                     // (foo x y) -> (app (app foo x) y)
                     let mut res = Sexp::List(vec![app.clone(), list[0].clone(), list[1].clone()]);
@@ -80,8 +72,8 @@ pub fn curry_sexp(e: &Sexp) -> Sexp {
                     res
                 }
             }
-        },
-        Sexp::Atom(atom) => Sexp::Atom(atom.clone())
+        }
+        Sexp::Atom(atom) => Sexp::Atom(atom.clone()),
     }
 }
 
@@ -90,9 +82,9 @@ pub fn programs_info(programs: &Vec<Expr>) {
     let max_cost = programs.iter().map(|p| p.cost()).max().unwrap();
     let max_depth = programs.iter().map(|p| p.depth()).max().unwrap();
     println!("Programs:");
-    println!("\t num: {}",programs.len());
-    println!("\t max cost: {}",max_cost);
-    println!("\t max depth: {}",max_depth);
+    println!("\t num: {}", programs.len());
+    println!("\t max cost: {}", max_cost);
+    println!("\t max depth: {}", max_depth);
 }
 
 /// provides a timestamp as a string in a format you can use for file/folder names: YYYY-MM-DD_HH-MM-SS
@@ -100,50 +92,65 @@ pub fn timestamp() -> String {
     format!("{}", chrono::Local::now().format("%Y-%m-%d_%H-%M-%S"))
 }
 
-pub fn save(egraph: &EGraph, name: &str, outdir: &str) 
-{
-    egraph.dot().to_png(format!("{}/{}.png",outdir,name)).unwrap();
+pub fn save(egraph: &EGraph, name: &str, outdir: &str) {
+    egraph
+        .dot()
+        .to_png(format!("{}/{}.png", outdir, name))
+        .unwrap();
 }
 
-pub fn egraph_info(egraph: &EGraph) -> String 
-{
-    format!("{} nodes, {} classes, {} memo", egraph.total_number_of_nodes(), egraph.number_of_classes(), egraph.total_size())
+pub fn egraph_info(egraph: &EGraph) -> String {
+    format!(
+        "{} nodes, {} classes, {} memo",
+        egraph.total_number_of_nodes(),
+        egraph.number_of_classes(),
+        egraph.total_size()
+    )
 }
 
 /// convenience function for returning arguments from a DSL function
-pub fn ok<T: Into<Val<D>> , D:Domain>(v: T) -> VResult<D> {
+pub fn ok<T: Into<Val<D>>, D: Domain>(v: T) -> VResult<D> {
     Ok(v.into())
 }
 
 /// convenience function for equality assertions
-pub fn assert_eq_val<D:Domain, T>(v: &Val<D>, o: T)
-where T: From<Val<D>>+ Debug + PartialEq
+pub fn assert_eq_val<D: Domain, T>(v: &Val<D>, o: T)
+where
+    T: From<Val<D>> + Debug + PartialEq,
 {
     assert_eq!(T::from(v.clone()), o);
 }
 
 /// convenience function for asserting that something executes to what you'd expect
 pub fn assert_execution<D: Domain, T>(expr: &str, args: &[Val<D>], expected: T)
-where T: From<Val<D>>+ Debug + PartialEq
+where
+    T: From<Val<D>> + Debug + PartialEq,
 {
     let e: Executable<D> = expr.parse().unwrap();
-    let mut args: Vec<LazyVal<D>> = args.iter().map(|arg|LazyVal::new_strict(arg.clone())).collect();
+    let mut args: Vec<LazyVal<D>> = args
+        .iter()
+        .map(|arg| LazyVal::new_strict(arg.clone()))
+        .collect();
     let res = e.eval(&mut args).unwrap();
-    assert_eq_val(&res,expected);
+    assert_eq_val(&res, expected);
 }
 
 pub fn assert_error<D: Domain, T>(expr: &str, args: &[Val<D>], expected_error_msg: String)
-where T: From<Val<D>>+ Debug + PartialEq
+where
+    T: From<Val<D>> + Debug + PartialEq,
 {
     let e: Executable<D> = expr.parse().unwrap();
-    let mut args: Vec<LazyVal<D>> = args.iter().map(|arg|LazyVal::new_strict(arg.clone())).collect();
+    let mut args: Vec<LazyVal<D>> = args
+        .iter()
+        .map(|arg| LazyVal::new_strict(arg.clone()))
+        .collect();
     let res = e.eval(&mut args);
     assert!(res.is_err());
     assert_eq!(expected_error_msg, res.err().unwrap());
 }
 
 pub fn compression_factor(original: &Expr, compressed: &Expr) -> f64 {
-    f64::from(original.cost())/f64::from(compressed.cost())
+    f64::from(original.cost()) / f64::from(compressed.cost())
 }
 
 /// Replace the ivars in an expr based on an i32->Expr map
@@ -152,9 +159,9 @@ pub fn ivar_replace(e: &Expr, child: Id, map: &AHashMap<i32, Expr>) -> Expr {
         Lambda::IVar(i) => map.get(&i).unwrap_or(&e).clone(),
         Lambda::Var(v) => Expr::var(*v),
         Lambda::Prim(p) => Expr::prim(*p),
-        Lambda::App([f,x]) => Expr::app(ivar_replace(e, *f, map), ivar_replace(e, *x, map)),
+        Lambda::App([f, x]) => Expr::app(ivar_replace(e, *f, map), ivar_replace(e, *x, map)),
         Lambda::Lam([b]) => Expr::lam(ivar_replace(e, *b, map)),
-        Lambda::Programs(_) => panic!("why would you do this")
+        Lambda::Programs(_) => panic!("why would you do this"),
     }
 }
 
@@ -164,13 +171,20 @@ pub fn ivar_to_dc(e: &Expr, child: Id, depth: i32, arity: i32) -> Expr {
         Lambda::IVar(i) => Expr::var(depth + (arity - 1 - i)), // the higher the ivar the smaller the var
         Lambda::Var(v) => Expr::var(*v),
         Lambda::Prim(p) => Expr::prim(*p),
-        Lambda::App([f,x]) => Expr::app(ivar_to_dc(e, *f, depth, arity), ivar_to_dc(e, *x, depth, arity)),
-        Lambda::Lam([b]) => Expr::lam(ivar_to_dc(e, *b, depth+1, arity)),
-        Lambda::Programs(_) => panic!("why would you do this")
+        Lambda::App([f, x]) => Expr::app(
+            ivar_to_dc(e, *f, depth, arity),
+            ivar_to_dc(e, *x, depth, arity),
+        ),
+        Lambda::Lam([b]) => Expr::lam(ivar_to_dc(e, *b, depth + 1, arity)),
+        Lambda::Programs(_) => panic!("why would you do this"),
     }
 }
 
-pub fn dc_inv_str(inv: &Invention, past_step_results: &Vec<CompressionStepResult>) -> String {
+pub fn dc_inv_str(
+    inv: &Invention,
+    past_step_results: &Vec<CompressionStepResult>,
+    prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
+) -> String {
     let mut body: Expr = ivar_to_dc(&inv.body, inv.body.root(), 0, inv.arity as i32);
     // wrap in lambdas for dremacoder
     for _ in 0..inv.arity {
@@ -179,9 +193,17 @@ pub fn dc_inv_str(inv: &Invention, past_step_results: &Vec<CompressionStepResult
     // add the "#" that dreamcoder wants and change lam -> lambda
     let mut res: String = format!("#{}", body);
     res = res.replace("(lam ", "(lambda ");
+    // inline any past inventions from the existing DSL.
+    for (past_inv_name, past_dc_inv_str) in prev_dc_inv_to_inv_strs {
+        res = replace_prim_with(&res, past_inv_name, past_dc_inv_str);
+    }
     // inline any past inventions using their dc_inv_str. Match on "fn_i)" and "fn_i " to avoid matching fn_1 on fn_10 or any other prefix
     for past_step_result in past_step_results.iter() {
-        res = replace_prim_with(&res, &past_step_result.inv.name, &past_step_result.dc_inv_str);
+        res = replace_prim_with(
+            &res,
+            &past_step_result.inv.name,
+            &past_step_result.dc_inv_str,
+        );
         // res = res.replace(&format!("{})",past_step_result.inv.name), &format!("{})",past_step_result.dc_inv_str));
         // res = res.replace(&format!("{} ",past_step_result.inv.name), &format!("{} ", past_step_result.dc_inv_str));
     }
@@ -190,18 +212,18 @@ pub fn dc_inv_str(inv: &Invention, past_step_results: &Vec<CompressionStepResult
 
 pub fn replace_prim_with(s: &str, prim: &str, new: &str) -> String {
     let mut res: String = s.to_string();
-    res = res.replace(&format!(" {})",prim), &format!(" {})",new));
+    res = res.replace(&format!(" {})", prim), &format!(" {})", new));
     // we need to do the " {} " case twice to handle multioverlaps like fn_i fn_i fn_i fn_i which will replace at locations 1 and 3
     // in the first replace() and 2 and 4 in the second replace due to overlapping matches.
-    res = res.replace(&format!(" {} ",prim), &format!(" {} ",new));
-    res = res.replace(&format!(" {} ",prim), &format!(" {} ",new));
-    assert!(!res.contains(&format!(" {} ",prim)));
-    res = res.replace(&format!("({} ",prim), &format!("({} ",new));
-    if res.starts_with(&format!("{} ",prim)) {
+    res = res.replace(&format!(" {} ", prim), &format!(" {} ", new));
+    res = res.replace(&format!(" {} ", prim), &format!(" {} ", new));
+    assert!(!res.contains(&format!(" {} ", prim)));
+    res = res.replace(&format!("({} ", prim), &format!("({} ", new));
+    if res.starts_with(&format!("{} ", prim)) {
         res = format!("{} {}", new, &res[prim.len()..]);
     }
-    if res.ends_with(&format!(" {}",prim)) {
-        res = format!("{} {}", &res[..res.len()-prim.len()], new);
+    if res.ends_with(&format!(" {}", prim)) {
+        res = format!("{} {}", &res[..res.len() - prim.len()], new);
     }
     if res == prim {
         res = new.to_string();
@@ -210,136 +232,126 @@ pub fn replace_prim_with(s: &str, prim: &str, new: &str) -> String {
 }
 
 /// cache for shift()
-pub type RecVarModCache = AHashMap<(Id,i32),Option<Id>>;
-
+pub type RecVarModCache = AHashMap<(Id, i32), Option<Id>>;
 
 /// This is a helper function for implementing various recursive operations that only
 /// modify Var or IVar constructs (use `ivars=true` to run this on all ivars). Just provide
 /// a function that you want to call on each Var to determine what to replace it with. The function
 /// signature should be `(actual_idx, depth, which_upward_ref, egraph) -> Option<Id>`.
-/// 
+///
 /// We recurse over the full graph rooted at `eclass` and replace any `Var` (or `IVar` if `ivars=true`)
 /// with the result of calling the function with:
 /// * `actual_idx`: if we're matching on Var(i) this is i
 /// * `depth`: how many Lamdas are between this Var and the original toplevel eclass this was called on
 /// * `which_upward_ref`: this is just actual_idx-depth
 /// * `egraph`: the EGraph we're operating on
-/// 
+///
 /// Note that we wont touch any branches of the tree that dont have free variables with respect to the toplevel,
 /// so this will never be called on some Var(i) if it is not considered a free variable in `eclass` as a whole.
-/// 
+///
 /// This function is fairly efficient. We cache both within and between calls to it, it uses
 /// the enode data that tells us if there are no free variables in a branch (and thus it can be ignored),
 /// it operates on the structurally hashed form of the graph, etc.
 pub fn recursive_var_mod(
     var_mod: impl Fn(i32, i32, i32, &mut crate::EGraph) -> Option<Id>,
     ivars: bool,
-    eclass:Id,
+    eclass: Id,
     egraph: &mut crate::EGraph,
-    seen: &mut RecVarModCache
-    ) -> Option<Id>
-    {
-        recursive_var_mod_helper(
-            &var_mod,
-            ivars,
-            eclass,
-            0,
-            egraph,
-            seen,
-        )
+    seen: &mut RecVarModCache,
+) -> Option<Id> {
+    recursive_var_mod_helper(&var_mod, ivars, eclass, 0, egraph, seen)
 }
 
 /// see `recursive_var_mod`
 fn recursive_var_mod_helper(
     var_mod: &impl Fn(i32, i32, i32, &mut crate::EGraph) -> Option<Id>,
     ivars: bool, // whether to run this on vars or ivars
-    eclass:Id,
+    eclass: Id,
     depth: i32,
     egraph: &mut crate::EGraph,
-    seen : &mut RecVarModCache,
-    ) -> Option<Id>
+    seen: &mut RecVarModCache,
+) -> Option<Id> {
+    // important invariant for ivars=false case: a $i with i==depth would be a $0 pointer at the top level
+    // meaning i<depth is an internal pointer that doesnt break the top level
+    let eclass = egraph.find(eclass);
+    let key = (eclass, depth);
+
+    if seen.contains_key(&key) {
+        return seen[&key];
+    }
+
+    if (ivars && egraph[eclass].data.free_ivars.is_empty())
+        || (!ivars && egraph[eclass].data.free_vars.iter().all(|i| *i < depth))
     {
-        // important invariant for ivars=false case: a $i with i==depth would be a $0 pointer at the top level
-        // meaning i<depth is an internal pointer that doesnt break the top level
-        let eclass = egraph.find(eclass);
-        let key = (eclass,depth);
+        // if we're replacing ivars and theres no ivars in this subtree, we can return early
+        // if we're replacing vars, from our invariant (above) we know i<depth is an internal pointer that doesnt point out of the top level so again we can return early
+        seen.insert(key, Some(eclass));
+        return Some(eclass);
+    }
 
-        if seen.contains_key(&key) {
-            return seen[&key];
+    // this is for loop breaking (though there shouldnt be loops in my new DAG setup anyways)
+    seen.insert(key, None);
+
+    // if you want a multiple-node-per-eclass version of this that unions together the stuff from diff branches, see my old code!
+    assert!(egraph[eclass].nodes.len() == 1);
+    // clone to appease the borrow checker
+    let enode = egraph[eclass].nodes[0].clone();
+
+    let new_eclass = match enode {
+        Lambda::Var(i) => {
+            if ivars {
+                panic!("unreachable, Var doesnt have free IVars")
+            }
+            assert!(i >= depth); // otherwise we should have returned earlier
+                                 // by our invariant be have i-depth as the toplevel version of this index
+            var_mod(i, depth, i - depth, egraph)
         }
-
-        if  (ivars && egraph[eclass].data.free_ivars.is_empty())
-        || (!ivars && egraph[eclass].data.free_vars.iter().all(|i| *i < depth)) {
-            // if we're replacing ivars and theres no ivars in this subtree, we can return early
-            // if we're replacing vars, from our invariant (above) we know i<depth is an internal pointer that doesnt point out of the top level so again we can return early
-            seen.insert(key, Some(eclass));
-            return Some(eclass)
+        Lambda::IVar(i) => {
+            if !ivars {
+                panic!("unreachable, IVar doesnt have free Vars")
+            }
+            var_mod(i, depth, i - depth, egraph)
         }
-
-        // this is for loop breaking (though there shouldnt be loops in my new DAG setup anyways)
-        seen.insert(key, None);
-        
-        // if you want a multiple-node-per-eclass version of this that unions together the stuff from diff branches, see my old code!
-        assert!(egraph[eclass].nodes.len() == 1);
-        // clone to appease the borrow checker
-        let enode = egraph[eclass].nodes[0].clone();
-
-        let new_eclass = match enode {
-            Lambda::Var(i) => {
-                if ivars {
-                    panic!("unreachable, Var doesnt have free IVars")
-                }
-                assert!(i >= depth); // otherwise we should have returned earlier
-                // by our invariant be have i-depth as the toplevel version of this index
-                var_mod(i, depth, i-depth, egraph)
+        Lambda::Prim(_) => {
+            panic!("unreachable, Prim never has free vars/ivars")
+        }
+        Lambda::App([f, x]) => {
+            // recurse in each (class shift will return early if no shifting is needed) and build a new App
+            let fnew_opt = recursive_var_mod_helper(var_mod, ivars, f, depth, egraph, seen);
+            let xnew_opt = recursive_var_mod_helper(var_mod, ivars, x, depth, egraph, seen);
+            match (fnew_opt, xnew_opt) {
+                (Some(fnew), Some(xnew)) => Some(egraph.add(Lambda::App([fnew, xnew]))),
+                _ => None,
             }
-            Lambda::IVar(i) => {
-                if !ivars {
-                    panic!("unreachable, IVar doesnt have free Vars")
-                }
-                var_mod(i, depth, i-depth, egraph)
-            }
-            Lambda::Prim(_) => {
-                panic!("unreachable, Prim never has free vars/ivars")
-            }
-            Lambda::App([f, x]) => {
-                // recurse in each (class shift will return early if no shifting is needed) and build a new App
-                let fnew_opt = recursive_var_mod_helper(var_mod, ivars, f, depth, egraph, seen);
-                let xnew_opt = recursive_var_mod_helper(var_mod, ivars, x, depth, egraph, seen);
-                match (fnew_opt,xnew_opt) {
-                    (Some(fnew),Some(xnew)) => Some(egraph.add(Lambda::App([fnew, xnew]))),
-                    _ => None,
-                }
-            }
-            Lambda::Lam([b]) => {
-                // increment depth
-                recursive_var_mod_helper(var_mod, ivars, b, depth+1, egraph, seen)
+        }
+        Lambda::Lam([b]) => {
+            // increment depth
+            recursive_var_mod_helper(var_mod, ivars, b, depth + 1, egraph, seen)
                 .map(|bnew| egraph.add(Lambda::Lam([bnew])))
-            }
-            Lambda::Programs(_) => {
-                panic!("attempted to shift a Programs node")
-            }
-        };
-
-        if let Some(new_eclass) = new_eclass {
-            let new_eclass = egraph.find(new_eclass);
-            seen.insert(key, Some(new_eclass));
-            Some(new_eclass)
-        } else {
-            None
         }
+        Lambda::Programs(_) => {
+            panic!("attempted to shift a Programs node")
+        }
+    };
+
+    if let Some(new_eclass) = new_eclass {
+        let new_eclass = egraph.find(new_eclass);
+        seen.insert(key, Some(new_eclass));
+        Some(new_eclass)
+    } else {
+        None
+    }
 }
 
 #[inline]
 /// Takes a SORTED vector of copyable items and a key function and groups adjacent equal-key items
 /// into subvectors, returning the vector of these subvectors.
-pub fn group_by_key<T: Copy, U: Ord>(v: Vec<T>, key: impl Fn(&T)->U) -> Vec<Vec<T>> {
+pub fn group_by_key<T: Copy, U: Ord>(v: Vec<T>, key: impl Fn(&T) -> U) -> Vec<Vec<T>> {
     let mut group = vec![v[0]];
     let mut groups = vec![];
-    
     for i in 1..v.len() {
         // group zippers by their left sides being the same
-        if key(&v[i]) == key(&v[i-1]) {
+        if key(&v[i]) == key(&v[i - 1]) {
             // add on to old ztuplegroup
             group.push(v[i]);
         } else {
@@ -373,13 +385,12 @@ pub fn num_paths_to_node(roots: &[Id], treenodes: &Vec<Id>, egraph: &crate::EGra
 }
 
 /// same as Itertools::counts() but returns an AHashMap instead of a HashMap
-pub fn counts_ahash<T: Hash + Eq + Clone>(v: &Vec<T>) -> AHashMap<T, usize>
-{
+pub fn counts_ahash<T: Hash + Eq + Clone>(v: &Vec<T>) -> AHashMap<T, usize> {
     let mut counts = AHashMap::new();
-    v.iter().for_each(|item| *counts.entry(item.clone()).or_default() += 1);
+    v.iter()
+        .for_each(|item| *counts.entry(item.clone()).or_default() += 1);
     counts
 }
-
 
 // pub trait IterUtil : Iterator {
 //     /// same as Itertools::counts() but returns an AHashMap instead of a HashMap


### PR DESCRIPTION
Threads the DC inventions names through rewrite.rs and compress.rs.

Specifically, this:
- Bundles up the tuple passed by InputFormat into a `Input` struct. This is a pretty minimal struct right now.
- Adds instances of renaming the dc_invs back to their inlined form in: the creation of the CompressionStepResult in `compress.rs` to rename the *dreamcoder invention bodies* AND the *rewritten dreamcoder programs*; and also does this again in `rewrite.rs`.
- I also had to change the naming scheme for previous DC inventions in general. This is because there's a discontinuity here between the OLD invention names (which can actually be in the bodies of the inventions that we read in for rewriting) and the NEW invention names. I hope this doesn't introduce some kind of drastic string ordering issue that requires globally re-ordering everything. I'm going to sanity check our domains to make sure they return the same results.

I also...realized that this runs Black over the rust code and that makes this PR quite annoying to look at. If you want I can try and understand how to undo that.