### PR TITLE
Update compression and rewriting to take in programs with existing DC inventions.

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1448,7 +1448,7 @@ impl CompressionStepResult {
         let rewritten_dreamcoder: Vec<String> = rewritten.split_programs().iter().map(|p|{
             let mut res = p.to_string();
             for (prev_inv_name, prev_dc_inv_str) in prev_dc_inv_to_inv_strs {
-                res = replace_prim_with(&res, &prev_inv_name, &prev_dc_inv_str);
+                res = replace_prim_with(&res, prev_inv_name, prev_dc_inv_str);
                 // res = res.replace(&format!("{})",past_inv.inv.name), &format!("{})",past_inv.dc_inv_str));
                 // res = res.replace(&format!("{} ",past_inv.inv.name), &format!("{} ",past_inv.dc_inv_str));
             }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1412,7 +1412,7 @@ pub struct CompressionStepResult {
 }
 
 impl CompressionStepResult {
-    fn new(done: FinishedPattern, inv_name: &str, shared: &mut SharedData, past_invs: &[CompressionStepResult]) -> Self {
+    fn new(done: FinishedPattern, inv_name: &str, shared: &mut SharedData, past_invs: &[CompressionStepResult], prev_dc_inv_to_inv_strs: &Vec<(String, String)>) -> Self {
 
         // cost of the very first initial program before any inventions
         let very_first_cost = if let Some(past_inv) = past_invs.first() { past_inv.initial_cost } else { shared.init_cost };
@@ -1435,17 +1435,25 @@ impl CompressionStepResult {
                 extract(shared.arg_of_zid_node[*zid][node].shifted_id, &shared.egraph)
             ).collect()).collect();
         
+        // Combine the past_invs with the existing dreamcoder inventions.
+        let mut dreamcoder_translations: Vec<(String, String)>  = past_invs.iter().map(|compression_step_result| (compression_step_result.inv.name.clone(), compression_step_result.dc_inv_str.clone())).collect();
+
+        dreamcoder_translations.extend(prev_dc_inv_to_inv_strs.iter().cloned());
+
         // dreamcoder compatability
-        let dc_inv_str: String = dc_inv_str(&inv, past_invs);
+        let dc_inv_str: String = dc_inv_str(&inv, &dreamcoder_translations);
         // Rewrite to dreamcoder syntax with all past invention
         // we rewrite "inv1)" and "inv1 " instead of just "inv1" because we dont want to match on "inv10"
+
         let rewritten_dreamcoder: Vec<String> = rewritten.split_programs().iter().map(|p|{
             let mut res = p.to_string();
-            for past_inv in past_invs {
-                res = replace_prim_with(&res, &past_inv.inv.name, &past_inv.dc_inv_str);
+            for (prev_inv_name, prev_dc_inv_str) in prev_dc_inv_to_inv_strs {
+                res = replace_prim_with(&res, &prev_inv_name, &prev_dc_inv_str);
                 // res = res.replace(&format!("{})",past_inv.inv.name), &format!("{})",past_inv.dc_inv_str));
                 // res = res.replace(&format!("{} ",past_inv.inv.name), &format!("{} ",past_inv.dc_inv_str));
             }
+
+            // Now go ahead and replace the current invention.
             res = replace_prim_with(&res, inv_name, &dc_inv_str);
             // res = res.replace(&format!("{})",inv_name), &format!("{})",dc_inv_str));
             // res = res.replace(&format!("{} ",inv_name), &format!("{} ",dc_inv_str));
@@ -1845,9 +1853,9 @@ pub fn compression(
     iterations: usize,
     cfg: &CompressionStepConfig,
     tasks: &[String],
-    num_prior_inventions: usize,
+    prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
 ) -> Vec<CompressionStepResult> {
-
+    let num_prior_inventions = prev_dc_inv_to_inv_strs.len();
     let mut rewritten: Expr = programs_expr.clone();
     let mut step_results: Vec<CompressionStepResult> = Default::default();
 
@@ -1863,7 +1871,8 @@ pub fn compression(
             &inv_name,
             cfg,
             &step_results,
-            tasks);
+            tasks,
+            prev_dc_inv_to_inv_strs,);
 
         if !res.is_empty() {
             // rewrite with the invention
@@ -1911,6 +1920,7 @@ pub fn compression_step(
     cfg: &CompressionStepConfig,
     past_invs: &[CompressionStepResult], // past inventions we've found
     tasks: &[String],
+    prev_dc_inv_to_inv_strs: &Vec<(String, String)>,
 ) -> Vec<CompressionStepResult> {
 
     let tstart_total = std::time::Instant::now();
@@ -2143,7 +2153,7 @@ pub fn compression_step(
     // construct CompressionStepResults and print some info about them)
     println!("Cost before: {}", shared.init_cost);
     for (i,done) in donelist.iter().enumerate() {
-        let res = CompressionStepResult::new(done.clone(), new_inv_name, &mut shared, past_invs);
+        let res = CompressionStepResult::new(done.clone(), new_inv_name, &mut shared, past_invs, prev_dc_inv_to_inv_strs);
 
         println!("{}: {}", i, res);
         if cfg.show_rewritten {

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -11,8 +11,14 @@ pub enum InputFormat {
     ProgramsList
 }
 
+pub struct Input {
+    pub programs : Vec<String>, // Program strings. 
+    pub tasks : Vec<String>, // Task names for each corresponding string.
+    pub prev_dc_inv_to_inv_strs: Vec<(String, String)>, // Vec of [#Dreamcoder invention, fn_i] tuples for any existing inventions in the DSL.
+}
+
 impl InputFormat {
-    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<(Vec<String>, Vec<String>, usize), String> {
+    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<(Input), String> {
         match *self {
             InputFormat::Dreamcoder => {
                 // read dreamcoder format
@@ -22,9 +28,11 @@ impl InputFormat {
                     .filter(|s| s.starts_with('#'))
                     .collect();
                 dc_invs.sort_by_key(|s| s.len()); // increasing length so inventions that build on earlier ones come later
-                let inv_dc_strs: Vec<(String,String)> = dc_invs.into_iter().enumerate()
-                    .map(|(i,dc_str)| (format!("fn_{}",i),dc_str)).collect();
-                let num_prior_inventions: usize = inv_dc_strs.len();
+                let inv_dc_strs: Vec<(String, String)> = dc_invs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, dc_str)| (format!("prev_dc_inv_{}", i), dc_str)) // TODO: determine if we need to replace these in the future.
+                    .collect();
                 let mut programs: Vec<String> = Vec::default();
                 let mut tasks: Vec<String> = Vec::default();
                 for (i,frontier) in frontiers.iter().enumerate() {
@@ -40,7 +48,12 @@ impl InputFormat {
                     programs.extend(programs_in_frontier);
                     tasks.extend(task_repeated);
                 }
-                Ok((programs, tasks, num_prior_inventions))
+                let input = Input {
+                    programs,
+                    tasks,
+                    prev_dc_inv_to_inv_strs: inv_dc_strs,
+                };
+                Ok(input)
             }
             InputFormat::ProgramsList => {
                 let programs: Vec<String> = from_reader(File::open(path).map_err(|e| format!("file not found, error code {:?}", e))?).map_err(|e| format!("json parser error, are you sure you wanted format {:?}? Error code was {:?}", self, e))?;
@@ -52,7 +65,12 @@ impl InputFormat {
                 while programs.iter().any(|p| p.contains(&format!("fn_{}", num_prior_inventions))) {
                     num_prior_inventions += 1;
                 }
-                Ok((programs, tasks, num_prior_inventions))
+                let input = Input {
+                    programs,
+                    tasks,
+                    prev_dc_inv_to_inv_strs: Vec::new(),
+                };
+                Ok(input)
             }
         }
     }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -18,7 +18,7 @@ pub struct Input {
 }
 
 impl InputFormat {
-    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<(Input), String> {
+    pub fn load_programs_and_tasks(&self, path: &Path) -> Result<Input, String> {
         match *self {
             InputFormat::Dreamcoder => {
                 // read dreamcoder format

--- a/src/util.rs
+++ b/src/util.rs
@@ -170,7 +170,7 @@ pub fn ivar_to_dc(e: &Expr, child: Id, depth: i32, arity: i32) -> Expr {
     }
 }
 
-pub fn dc_inv_str(inv: &Invention, dreamcoder_translations: &Vec<(String, String)>) -> String {
+pub fn dc_inv_str(inv: &Invention, dreamcoder_translations: &[(String, String)]) -> String {
     let mut body: Expr = ivar_to_dc(&inv.body, inv.body.root(), 0, inv.arity as i32);
     // wrap in lambdas for dremacoder
     for _ in 0..inv.arity {

--- a/src/util.rs
+++ b/src/util.rs
@@ -170,7 +170,7 @@ pub fn ivar_to_dc(e: &Expr, child: Id, depth: i32, arity: i32) -> Expr {
     }
 }
 
-pub fn dc_inv_str(inv: &Invention, past_step_results: &[CompressionStepResult]) -> String {
+pub fn dc_inv_str(inv: &Invention, dreamcoder_translations: &Vec<(String, String)>) -> String {
     let mut body: Expr = ivar_to_dc(&inv.body, inv.body.root(), 0, inv.arity as i32);
     // wrap in lambdas for dremacoder
     for _ in 0..inv.arity {
@@ -180,8 +180,8 @@ pub fn dc_inv_str(inv: &Invention, past_step_results: &[CompressionStepResult]) 
     let mut res: String = format!("#{}", body);
     res = res.replace("(lam ", "(lambda ");
     // inline any past inventions using their dc_inv_str. Match on "fn_i)" and "fn_i " to avoid matching fn_1 on fn_10 or any other prefix
-    for past_step_result in past_step_results.iter() {
-        res = replace_prim_with(&res, &past_step_result.inv.name, &past_step_result.dc_inv_str);
+    for (inv_name, dc_translation) in dreamcoder_translations.iter() {
+        res = replace_prim_with(&res, inv_name, dc_translation);
         // res = res.replace(&format!("{})",past_step_result.inv.name), &format!("{})",past_step_result.dc_inv_str));
         // res = res.replace(&format!("{} ",past_step_result.inv.name), &format!("{} ", past_step_result.dc_inv_str));
     }


### PR DESCRIPTION
Updates compress.rs and rewrite.rs to additionally use and rewrite using inventions in the 'DSL' field of dc_formatted programs.

There is some string trickiness going on here, necessitating the use of a different prefix for older dc_fmt_inventions, partly because `rewrite.rs` looks to a stitch_output.js file that actually NO LONGER contains all of the dependent inventions (some of them may be previous_dc_inventions). 

I've tested this on various nuts_bolts splits, but could use a sanity check of the string logic here.