### PR TITLE
Added minimal train/test splitting

### DIFF
--- a/src/formats.rs
+++ b/src/formats.rs
@@ -86,7 +86,7 @@ impl InputFormat {
                     tasks.push(task_num.to_string());
                 }
                 let mut  num_prior_inventions = 0;
-                while train_programs.iter().any(|p| p.contains(&format!("fn_{}", num_prior_inventions))) {
+                while train_programs.iter().chain(test_programs.iter()).any(|p| p.contains(&format!("fn_{}", num_prior_inventions))) {
                     num_prior_inventions += 1;
                 }
                 let input = Input {


### PR DESCRIPTION
This just adds:
- An input format that has split train/test data
- (Slow) rewriting of the test data after all the inventions have been found

In particular it does *not* add support for rewriting the test set with each invention found as you go along, because that requires a lot more code changes and we don't need it for POPL.