### PR TITLE
Eta Long ( + small indexing bugfix)

### DIFF
--- a/src/bin/compress.rs
+++ b/src/bin/compress.rs
@@ -35,7 +35,7 @@ fn main() {
 
     let input = args.fmt.load_programs_and_tasks(&args.file).unwrap();
 
-    let (step_results, json_res) = multistep_compression(&input.train_programs, input.tasks, input.anonymous_to_named, None, &args.multistep);
+    let (step_results, json_res) = multistep_compression(&input.train_programs, input.tasks, input.name_mapping, None, &args.multistep);
 
     let out_path = &args.out;
     if let Some(out_path_dir) = out_path.parent() {

--- a/src/bin/compress.rs
+++ b/src/bin/compress.rs
@@ -45,9 +45,9 @@ fn main() {
     }
 
     std::fs::write(out_path, serde_json::to_string_pretty(&json_res).unwrap()).unwrap();
-    if !args.multistep.silent{ println!("Wrote to {:?}", out_path) };
+    if !args.multistep.silent{ println!("Wrote to {out_path:?}") };
     if let Some(out_path) = args.save_rewritten {
-        if !args.multistep.silent{ println!("Wrote rewritten things to {:?}", out_path) };
+        if !args.multistep.silent{ println!("Wrote rewritten things to {out_path:?}") };
         std::fs::write(&out_path, serde_json::to_string_pretty(&step_results.iter().last().unwrap().rewritten.iter().map(|p| p.to_string()).collect::<Vec<String>>()).unwrap()).unwrap();
     }
 

--- a/src/bin/rewrite.rs
+++ b/src/bin/rewrite.rs
@@ -79,9 +79,9 @@ fn main() {
     let inventions = inventions_data["abstractions"].as_array().unwrap();
 
 
-    let mut anonymous_to_named = input.anonymous_to_named.clone().unwrap_or_default();
-    anonymous_to_named.extend(inventions.iter().map(|invention| (invention["name"].as_str().unwrap().to_string(),invention["dreamcoder"].as_str().unwrap().to_string())));
-    anonymous_to_named.sort_by_key(|(_, dc_name)| dc_name.len());
+    let mut name_mapping = input.name_mapping.clone().unwrap_or_default();
+    name_mapping.extend(inventions.iter().map(|invention| (invention["name"].as_str().unwrap().to_string(),invention["dreamcoder"].as_str().unwrap().to_string())));
+    name_mapping.sort_by_key(|(_, dc_name)| dc_name.len());
 
     let inventions: Vec<Invention> = inventions
         .iter()
@@ -110,7 +110,7 @@ fn main() {
                 let task_name = input.tasks.clone().map(|tasks| tasks[i].clone()).unwrap_or_else(||i.to_string());
                 let mut pretty_program = pretty_program.to_string();
                 if args.dreamcoder_output {
-                    for (name, dc_translation) in anonymous_to_named.iter().rev() {
+                    for (name, dc_translation) in name_mapping.iter().rev() {
                         pretty_program = replace_prim_with(&pretty_program, name, dc_translation);
                     }
                 }

--- a/src/bin/rewrite.rs
+++ b/src/bin/rewrite.rs
@@ -43,12 +43,12 @@ pub struct RewriteArgs {
     #[clap(long, arg_enum, default_value = "programs-list")]
     pub fmt: InputFormat,
 
-    #[clap(flatten)]
-    pub cost: CostConfig,
-
     /// return the rewritten programs in dreamcoder (#(lambda)) format
     #[clap(long)]
     pub dreamcoder_output: bool,
+
+    #[clap(flatten)]
+    pub cost: MultistepCompressionConfig,
 }
 
 // Match the relevant input format.

--- a/src/bin/stats.rs
+++ b/src/bin/stats.rs
@@ -51,7 +51,7 @@ fn main() {
     let (mean_depth, std_depth) = get_stats(&depths);
 
     println!("Number of programs: {}", programs.len());
-    println!("Costs: mean={:.2}, std={:.2}", mean_cost, std_cost);
-    println!("Lengths: mean={:.2}, std={:.2}", mean_length, std_length);
-    println!("Depths: mean={:.2}, std={:.2}", mean_depth, std_depth);
+    println!("Costs: mean={mean_cost:.2}, std={std_cost:.2}");
+    println!("Lengths: mean={mean_length:.2}, std={std_length:.2}");
+    println!("Depths: mean={mean_depth:.2}, std={std_depth:.2}");
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -54,6 +54,11 @@ pub struct MultistepCompressionConfig {
     #[clap(long)]
     pub silent: bool,
 
+    /// Very verbose when rewriting happens - turns off --silent and --quiet which are usually forced on
+    /// in rewriting
+    #[clap(long)]
+    pub verbose_rewrite: bool,
+
     #[clap(flatten)]
     pub step: CompressionStepConfig,
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -496,9 +496,9 @@ impl std::fmt::Display for ExpandsTo {
         match self {
             ExpandsTo::Lam => write!(f, "(lam ??)"),
             ExpandsTo::App => write!(f, "(?? ??)"),
-            ExpandsTo::Var(v) => write!(f, "${}", v),
-            ExpandsTo::Prim(p) => write!(f, "{}", p),
-            ExpandsTo::IVar(v) => write!(f, "#{}", v),
+            ExpandsTo::Var(v) => write!(f, "${v}"),
+            ExpandsTo::Prim(p) => write!(f, "{p}"),
+            ExpandsTo::IVar(v) => write!(f, "#{v}"),
         }
     }
 }
@@ -926,7 +926,7 @@ fn stitch_search(
                         && locs.iter().all(|node| shared.tasks_of_node[*node].len() == 1)
                         && locs.iter().all(|node| shared.tasks_of_node[locs[0]].iter().next() == shared.tasks_of_node[*node].iter().next()) {
                     if !shared.cfg.no_stats { shared.stats.lock().deref_mut().single_task_fired += 1; }
-                    if tracked && !shared.cfg.quiet { println!("{} single task pruned when expanding {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), zipper_replace(original_pattern.to_expr(&shared), &shared.zip_of_zid[hole_zid], Node::Prim(format!("<{}>",expands_to).into()))) }
+                    if tracked && !shared.cfg.quiet { println!("{} single task pruned when expanding {} to {}", "[TRACK]".red().bold(), original_pattern.to_expr(&shared), zipper_replace(original_pattern.to_expr(&shared), &shared.zip_of_zid[hole_zid], Node::Prim(format!("<{expands_to}>").into()))) }
                     continue 'expansion;
                 }
 
@@ -1364,7 +1364,7 @@ impl CompressionStepResult {
         let final_cost = shared.root_idxs_of_task.iter().map(|root_idxs|
             root_idxs.iter().map(|idx| rewritten[*idx].cost(&shared.cost_fn)).min().unwrap()
         ).sum::<i32>();
-        if expected_cost != final_cost && !shared.cfg.quiet { println!("*** expected cost {} != final cost {}", expected_cost, final_cost) }
+        if expected_cost != final_cost && !shared.cfg.quiet { println!("*** expected cost {expected_cost} != final cost {final_cost}") }
         let multiplier = shared.init_cost as f64 / final_cost as f64;
         let multiplier_wrt_orig = very_first_cost as f64 / final_cost as f64;
         let uses = done.usages;
@@ -1761,7 +1761,7 @@ pub fn multistep_compression_internal(
 
 
     for i in 0..cfg.iterations {
-        if !cfg.step.quiet { println!("{}",format!("\n=======Iteration {}=======",i).blue().bold()) }
+        if !cfg.step.quiet { println!("{}",format!("\n=======Iteration {i}=======").blue().bold()) }
         let inv_name = if let Some(follow) = &follow {
             cfg.step.follow = Some(follow[i].body.to_string());
             follow[i].name.clone()
@@ -1790,7 +1790,7 @@ pub fn multistep_compression_internal(
             // if `follow` was given then we will keep going for the full set of iterations
             if !cfg.step.quiet { println!("Invention not found: {}", cfg.step.follow.as_ref().unwrap() ) }
         } else {
-            if !cfg.step.quiet { println!("No inventions found at iteration {}",i) }
+            if !cfg.step.quiet { println!("No inventions found at iteration {i}") }
             break;    
         }
     }
@@ -2136,7 +2136,7 @@ pub fn compression_step(
     if !shared.cfg.quiet { println!("Cost before: {}", shared.init_cost) }
     for (i,done) in donelist.iter().enumerate() {
         let res = CompressionStepResult::new(done.clone(), new_inv_name, &mut shared, very_first_cost, name_mapping, dc_comparison_millis);
-        if !shared.cfg.quiet { println!("{}: {}", i, res) }
+        if !shared.cfg.quiet { println!("{i}: {res}") }
         results.push(res);
     }
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -114,10 +114,6 @@ pub struct CompressionStepConfig {
     #[clap(long)]
     pub no_mismatch_check: bool,
 
-    /// Makes it so inventions cant start with a lambda at the top
-    #[clap(long)]
-    pub no_top_lambda: bool,
-
     /// Pattern or abstraction to follow and give prinouts about. If `follow_prune=True` we will aggressively prune to
     /// only follow this pattern, otherwise we will just verbosely print when ancestors of this pattern
     /// are encountered.
@@ -394,7 +390,8 @@ impl Pattern {
             }
         }
 
-        if cfg.no_top_lambda {
+        // to guarantee eta long we cant allow abstractions to start with a lambda at the top
+        if cfg.eta_long {
             match_locations.retain(|node| expands_to_of_node(&set[*node]) != ExpandsTo::Lam);
         }
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -348,9 +348,7 @@ impl Pattern {
         let body_utility = 0;
         let mut match_locations: Vec<Idx> = corpus_span.clone().collect();
         match_locations.sort(); // we assume match_locations is always sorted
-        if cfg.no_top_lambda {
-            match_locations.retain(|node| expands_to_of_node(&set[*node]) != ExpandsTo::Lam);
-        }
+        
         if cfg.eta_long {
 
             assert!(cfg.utility_by_rewrite || cfg.no_mismatch_check, "eta long form requires utility_by_rewrite or no_mismatch_check");
@@ -390,6 +388,11 @@ impl Pattern {
                 }
             }
         }
+
+        if cfg.no_top_lambda {
+            match_locations.retain(|node| expands_to_of_node(&set[*node]) != ExpandsTo::Lam);
+        }
+
         let utility_upper_bound = utility_upper_bound(&match_locations, body_utility, cost_of_node_all, num_paths_to_node, cost_fn, cfg);
         Pattern {
             holes: vec![EMPTY_ZID], // (zid 0 is the empty zipper)

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1744,7 +1744,9 @@ pub fn multistep_compression_internal(
         assert_eq!(follow.len(), cfg.iterations);
         cfg.step.follow_prune = true;
         cfg.step.rewrite_check = false; // this will cause a loop
-        cfg.step.quiet = true;
+        if !cfg.verbose_rewrite{
+            cfg.step.quiet = true;
+        }
         cfg.step.no_opt();
     }
 

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -16,7 +16,7 @@ pub enum InputFormat {
 pub struct Input {
     pub train_programs: Vec<String>, // Program strings. 
     pub tasks: Option<Vec<String>>, // Task names for each corresponding string.
-    pub anonymous_to_named: Option<Vec<(String, String)>>, // Vec of [#Dreamcoder invention, fn_i] tuples for any existing inventions in the DSL.
+    pub name_mapping: Option<Vec<(String, String)>>, // Vec of [#Dreamcoder invention, fn_i] tuples for any existing inventions in the DSL.
 }
 
 impl InputFormat {
@@ -55,7 +55,7 @@ impl InputFormat {
                 let input = Input {
                     train_programs: programs,
                     tasks: Some(tasks),
-                    anonymous_to_named: Some(inv_dc_strs),
+                    name_mapping: Some(inv_dc_strs),
                 };
                 Ok(input)
             }
@@ -64,7 +64,7 @@ impl InputFormat {
                 let input = Input {
                     train_programs: programs,
                     tasks: None,
-                    anonymous_to_named: None,
+                    name_mapping: None,
                 };
                 Ok(input)
             }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -35,7 +35,7 @@ impl InputFormat {
                 let inv_dc_strs: Vec<(String, String)> = dc_invs
                     .into_iter()
                     .enumerate()
-                    .map(|(i, dc_str)| (format!("dreamcoder_abstraction_{}", i), dc_str)) // TODO: determine if we need to replace these in the future.
+                    .map(|(i, dc_str)| (format!("dreamcoder_abstraction_{i}"), dc_str)) // TODO: determine if we need to replace these in the future.
                     .collect();
                 let mut programs: Vec<String> = Vec::default();
                 let mut tasks: Vec<String> = Vec::default();
@@ -60,7 +60,7 @@ impl InputFormat {
                 Ok(input)
             }
             InputFormat::ProgramsList => {
-                let programs: Vec<String> = from_reader(File::open(path).map_err(|e| format!("file not found, error code {:?}", e))?).map_err(|e| format!("json parser error, are you sure you wanted format {:?}? Error code was {:?}", self, e))?;
+                let programs: Vec<String> = from_reader(File::open(path).map_err(|e| format!("file not found, error code {e:?}"))?).map_err(|e| format!("json parser error, are you sure you wanted format {self:?}? Error code was {e:?}"))?;
                 let input = Input {
                     train_programs: programs,
                     tasks: None,

--- a/src/rewriting.rs
+++ b/src/rewriting.rs
@@ -155,26 +155,26 @@ pub fn rewrite_fast(
 pub fn rewrite_with_inventions(
     programs: &[String],
     invs: &[Invention],
-    cfg: &CostConfig,
+    cfg: &MultistepCompressionConfig,
 ) -> (Vec<String>, Vec<CompressionStepResult>, serde_json::Value) {
 
     // if invs.is_empty() {
     //     return programs.to_vec()
     // }
 
+    let mut cfg = cfg.clone();
+
     // programs.to_vec()
     let follow = Some(invs.to_vec());
-    let mut multistep_cfg = MultistepCompressionConfig::new();
-    multistep_cfg.step.cost = cfg.clone();
-    multistep_cfg.iterations = invs.len();
-    multistep_cfg.step.max_arity = invs.iter().map(|inv| inv.arity).max().unwrap();
-    multistep_cfg.silent = true;
+    cfg.iterations = invs.len();
+    cfg.step.max_arity = invs.iter().map(|inv| inv.arity).max().unwrap();
+    cfg.silent = true;
 
     // ugh somewhat gross to just set this to true
-    multistep_cfg.step.rewritten_dreamcoder = true;
-    multistep_cfg.step.rewritten_intermediates = true;
+    cfg.step.rewritten_dreamcoder = true;
+    cfg.step.rewritten_intermediates = true;
 
-    let (step_results, json_res) = multistep_compression(programs, None, None, follow, &multistep_cfg);
+    let (step_results, json_res) = multistep_compression(programs, None, None, follow, &cfg);
 
     // return the last one - note that if an abstraction wasn't used anywhere it will not be included in the step_results so this
     // may be shorter than invs.len(), however we do ensure that we continue searching for the rest of the abstractions if this happens

--- a/src/rewriting.rs
+++ b/src/rewriting.rs
@@ -170,6 +170,11 @@ pub fn rewrite_with_inventions(
     cfg.step.max_arity = invs.iter().map(|inv| inv.arity).max().unwrap();
     cfg.silent = true;
 
+    if cfg.verbose_rewrite {
+        cfg.silent = false;
+        cfg.step.quiet = false;
+    }
+
     // ugh somewhat gross to just set this to true
     cfg.step.rewritten_dreamcoder = true;
     cfg.step.rewritten_intermediates = true;

--- a/src/rewriting.rs
+++ b/src/rewriting.rs
@@ -176,8 +176,8 @@ pub fn rewrite_with_inventions(
     }
 
     // ugh somewhat gross to just set this to true
-    cfg.step.rewritten_dreamcoder = true;
-    cfg.step.rewritten_intermediates = true;
+    // cfg.step.rewritten_dreamcoder = true;
+    // cfg.step.rewritten_intermediates = true;
 
     let (step_results, json_res) = multistep_compression(programs, None, None, follow, &cfg);
 

--- a/src/rewriting.rs
+++ b/src/rewriting.rs
@@ -75,7 +75,7 @@ pub fn rewrite_fast(
 
                         // wrap like: f => (f $1 $0)
                         for i in 0..arity_of_arg {
-                            let var = owned_set.add(Node::Var((arity_of_arg-i) as i32));
+                            let var = owned_set.add(Node::Var((arity_of_arg-i-1) as i32));
                             shifted_rewritten_arg = owned_set.add(Node::App(shifted_rewritten_arg, var));
                         }
                         // wrap in lambdas: (f $1 $0) => (lam (lam (f $1 $0)))

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,8 +21,8 @@ pub fn programs_info(programs: &[ExprOwned], cost_fn: &ExprCost) {
     let max_depth = programs.iter().map(|e| e.depth()).max().unwrap();
     println!("Programs:");
     println!("\t num: {}",programs.len());
-    println!("\t max cost: {}",max_cost);
-    println!("\t max depth: {}",max_depth); 
+    println!("\t max cost: {max_cost}");
+    println!("\t max depth: {max_depth}"); 
 }
 
 /// provides a timestamp as a string in a format you can use for file/folder names: YYYY-MM-DD_HH-MM-SS
@@ -61,7 +61,7 @@ pub fn dc_inv_str(inv: &Invention, dreamcoder_translations: &[(String, String)])
         body.idx = body.set.add(Node::Lam(body.idx));
     }
     // add the "#" that dreamcoder wants and change lam -> lambda
-    let mut res: String = format!("#{}", body);
+    let mut res: String = format!("#{body}");
     res = res.replace("(lam ", "(lambda ");
     // inline any past inventions using their dc_inv_str. Match on "fn_i)" and "fn_i " to avoid matching fn_1 on fn_10 or any other prefix
     for (inv_name, dc_translation) in dreamcoder_translations.iter() {
@@ -74,17 +74,17 @@ pub fn dc_inv_str(inv: &Invention, dreamcoder_translations: &[(String, String)])
 
 pub fn replace_prim_with(s: &str, prim: &str, new: &str) -> String {
     let mut res: String = s.to_string();
-    res = res.replace(&format!(" {})",prim), &format!(" {})",new));
+    res = res.replace(&format!(" {prim})"), &format!(" {new})"));
     // we need to do the " {} " case twice to handle multioverlaps like fn_i fn_i fn_i fn_i which will replace at locations 1 and 3
     // in the first replace() and 2 and 4 in the second replace due to overlapping matches.
-    res = res.replace(&format!(" {} ",prim), &format!(" {} ",new));
-    res = res.replace(&format!(" {} ",prim), &format!(" {} ",new));
-    assert!(!res.contains(&format!(" {} ",prim)));
-    res = res.replace(&format!("({} ",prim), &format!("({} ",new));
-    if res.starts_with(&format!("{} ",prim)) {
+    res = res.replace(&format!(" {prim} "), &format!(" {new} "));
+    res = res.replace(&format!(" {prim} "), &format!(" {new} "));
+    assert!(!res.contains(&format!(" {prim} ")));
+    res = res.replace(&format!("({prim} "), &format!("({new} "));
+    if res.starts_with(&format!("{prim} ")) {
         res = format!("{} {}", new, &res[prim.len()..]);
     }
-    if res.ends_with(&format!(" {}",prim)) {
+    if res.ends_with(&format!(" {prim}")) {
         res = format!("{} {}", &res[..res.len()-prim.len()], new);
     }
     if res == prim {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -13,9 +13,9 @@ fn write_json_for_diff(out: &Value, expected_out_path: &str) {
         }
     }
     std::fs::write(out_path, serde_json::to_string_pretty(&out).unwrap()).unwrap();
-    println!("Wrote test output to {:?} diff with expected out path {:?}", out_path, expected_out_path);
+    println!("Wrote test output to {out_path:?} diff with expected out path {expected_out_path:?}");
     println!("Command to replace:");
-    println!("cp {:?} {:?}", out_path, expected_out_path);
+    println!("cp {out_path:?} {expected_out_path:?}");
 }
 
 fn run_compression(inputs: &Input, cfg: &MultistepCompressionConfig) -> Value {
@@ -31,7 +31,7 @@ fn run_compression(inputs: &Input, cfg: &MultistepCompressionConfig) -> Value {
 fn compare_out_jsons(file: &str, expected_out_file: &str, args: &str, input_format: InputFormat) {
     let input = input_format.load_programs_and_tasks(std::path::Path::new(file)).unwrap();
 
-    let mut cfg = MultistepCompressionConfig::parse_from(format!("compress {}",args).split_whitespace());
+    let mut cfg = MultistepCompressionConfig::parse_from(format!("compress {args}").split_whitespace());
 
     cfg.previous_abstractions = input.name_mapping.clone().unwrap_or_default().len();
 
@@ -85,7 +85,7 @@ fn check_eq(actual: &Value, expected: &Value, path: Vec<String>, out: &Value, ex
             }
             for (i,(a,e)) in actual.iter().zip(expected.iter()).enumerate() {
                 let mut new_path = path.clone();
-                new_path.push(format!("{}",i));
+                new_path.push(format!("{i}"));
                 check_eq(a,e, new_path, out, expected_out_path);
             }
         }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -22,7 +22,7 @@ fn run_compression(inputs: &Input, cfg: &MultistepCompressionConfig) -> Value {
     multistep_compression(
         &inputs.train_programs,
         inputs.tasks.clone(),
-        inputs.anonymous_to_named.clone(),
+        inputs.name_mapping.clone(),
         None,
         cfg,
         ).1
@@ -33,7 +33,7 @@ fn compare_out_jsons(file: &str, expected_out_file: &str, args: &str, input_form
 
     let mut cfg = MultistepCompressionConfig::parse_from(format!("compress {}",args).split_whitespace());
 
-    cfg.previous_abstractions = input.anonymous_to_named.clone().unwrap_or_default().len();
+    cfg.previous_abstractions = input.name_mapping.clone().unwrap_or_default().len();
 
     let output = run_compression(&input, &cfg);
 


### PR DESCRIPTION
- eta long
- index shift bug was fixed that was originally triggered in claim-1 if you did utlity-by-rewrite and doesnt seem to notably change any results. The fix was when rewriting during the helper() recursion into an argument you should add the number of lambdas within the abstraction itself to your depth count. 
- arity zero optimization obeys eta_long and top_lambda ie instead of looking at all the corpus span they only look at valid match locations for the single-hole
- deleted unused refinements from rewriting code

Run claim 1 with eta long like:
```
EXTRA_STITCH_FLAGS="--eta-long --utility-by-rewrite" make claim-1
```
and while this is 10x slower than the original, thats all do to `utility-by-rewrite` not eta long itself
