### PR TITLE
allow ivars to be rewritten into other ivars

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1309,15 +1309,9 @@ fn _add_variable_reuse_to_buf(
         // println!("Zid considered for ivar {}: {}", ivar, original_pattern.first_zid_of_ivar[ivar]);
         let arg_of_loc_ivar = &shared.arg_of_zid_node[original_pattern.first_zid_of_ivar[ivar]];
         let locs: Vec<Idx> = original_pattern.match_locations.iter()
-            .filter(|loc:&&Idx|
-                {
-                    // if **loc == 9usize {
-                    //     // println!("Checking loc {}: {} vs {}", loc, arg_of_loc[loc].shifted_id, arg_of_loc_ivar[loc].shifted_id);
-                    // }
-                    return arg_of_loc[loc].shifted_id == 
+            .filter(|loc:&&Idx| arg_of_loc[loc].shifted_id == 
                 arg_of_loc_ivar[loc].shifted_id
                 && !invalid_metavar_location(shared, arg_of_loc[loc].shifted_id)
-                }
             ).cloned().collect();
         if locs.is_empty() { continue; }
         out.push((ExpandsTo::IVar(ivar as i32), locs));

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1287,18 +1287,7 @@ fn get_ivars_expansions(original_pattern: &Pattern, arg_of_loc: &FxHashMap<Idx,A
         }
     }
 
-    // consider all ivars used previously
-    for ivar in 0..original_pattern.first_zid_of_ivar.len() {
-        let arg_of_loc_ivar = &shared.arg_of_zid_node[original_pattern.first_zid_of_ivar[ivar]];
-        let locs: Vec<Idx> = original_pattern.match_locations.iter()
-            .filter(|loc:&&Idx|
-                arg_of_loc[loc].shifted_id == 
-                arg_of_loc_ivar[loc].shifted_id
-                && !invalid_metavar_location(shared, arg_of_loc[loc].shifted_id)
-            ).cloned().collect();
-        if locs.is_empty() { continue; }
-        ivars_expansions.push((ExpandsTo::IVar(ivar as i32), locs));
-    }
+    _add_variable_reuse_to_buf(original_pattern, arg_of_loc, shared, &mut ivars_expansions);
     // also consider one ivar greater, if this is within the arity limit. This will match at all the same locations as the original.
     if original_pattern.first_zid_of_ivar.len() < shared.cfg.max_arity {
         let ivar = original_pattern.first_zid_of_ivar.len();
@@ -1306,6 +1295,43 @@ fn get_ivars_expansions(original_pattern: &Pattern, arg_of_loc: &FxHashMap<Idx,A
         locs.retain(|loc| !invalid_metavar_location(shared, arg_of_loc[loc].shifted_id));
         ivars_expansions.push((ExpandsTo::IVar(ivar as i32), locs));
     }
+    ivars_expansions
+}
+
+fn _add_variable_reuse_to_buf(
+    original_pattern: &Pattern,
+    arg_of_loc: &FxHashMap<Idx,Arg>,
+    shared: &SharedData,
+    out: &mut Vec<(ExpandsTo, Vec<usize>)>
+) {
+    // consider all ivars used previously
+    for ivar in 0..original_pattern.first_zid_of_ivar.len() {
+        // println!("Zid considered for ivar {}: {}", ivar, original_pattern.first_zid_of_ivar[ivar]);
+        let arg_of_loc_ivar = &shared.arg_of_zid_node[original_pattern.first_zid_of_ivar[ivar]];
+        let locs: Vec<Idx> = original_pattern.match_locations.iter()
+            .filter(|loc:&&Idx|
+                {
+                    // if **loc == 9usize {
+                    //     // println!("Checking loc {}: {} vs {}", loc, arg_of_loc[loc].shifted_id, arg_of_loc_ivar[loc].shifted_id);
+                    // }
+                    return arg_of_loc[loc].shifted_id == 
+                arg_of_loc_ivar[loc].shifted_id
+                && !invalid_metavar_location(shared, arg_of_loc[loc].shifted_id)
+                }
+            ).cloned().collect();
+        if locs.is_empty() { continue; }
+        out.push((ExpandsTo::IVar(ivar as i32), locs));
+    }
+}
+
+pub fn get_ivars_variable_reuse(
+    original_pattern: &Pattern,
+    arg_of_loc: &FxHashMap<Idx,Arg>,
+    // shared: &Arc<SharedData>,
+    shared: &SharedData,
+) -> Vec<(ExpandsTo, Vec<Idx>)> {
+    let mut ivars_expansions = vec![];
+    _add_variable_reuse_to_buf(original_pattern, arg_of_loc, shared, &mut ivars_expansions);
     ivars_expansions
 }
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1308,14 +1308,19 @@ fn _add_variable_reuse_to_buf(
     for ivar in 0..original_pattern.first_zid_of_ivar.len() {
         // println!("Zid considered for ivar {}: {}", ivar, original_pattern.first_zid_of_ivar[ivar]);
         let arg_of_loc_ivar = &shared.arg_of_zid_node[original_pattern.first_zid_of_ivar[ivar]];
-        let locs: Vec<Idx> = original_pattern.match_locations.iter()
-            .filter(|loc:&&Idx| arg_of_loc[loc].shifted_id == 
-                arg_of_loc_ivar[loc].shifted_id
-                && !invalid_metavar_location(shared, arg_of_loc[loc].shifted_id)
-            ).cloned().collect();
+        let locs = compatible_locations(shared, original_pattern, arg_of_loc, arg_of_loc_ivar);
         if locs.is_empty() { continue; }
         out.push((ExpandsTo::IVar(ivar as i32), locs));
     }
+}
+
+pub fn compatible_locations(shared: &SharedData, original_pattern: &Pattern, arg_of_loc_1:  &FxHashMap<Idx,Arg>, arg_of_loc_2:  &FxHashMap<Idx,Arg>) -> Vec<usize> {
+    let locs: Vec<Idx> = original_pattern.match_locations.iter()
+        .filter(|loc:&&Idx| arg_of_loc_1[loc].shifted_id == 
+            arg_of_loc_2[loc].shifted_id
+            && !invalid_metavar_location(shared, arg_of_loc_1[loc].shifted_id)
+        ).cloned().collect();
+    locs
 }
 
 pub fn get_ivars_variable_reuse(

--- a/src/expand_variable.rs
+++ b/src/expand_variable.rs
@@ -98,7 +98,7 @@ pub fn perform_expansion_variable(
     let mut expands_to = expands_to;
 
 
-    check_consistency(shared, &pattern);
+    // check_consistency(shared, &pattern);
     // println!("expands_to: {:?}", expands_to);
     // println!("pattern: {:?}", pattern);
     // update the body utility
@@ -151,7 +151,7 @@ pub fn perform_expansion_variable(
 
     // println!("after adding variable: {:?}", new_pattern);
 
-    check_consistency(shared, &pattern);
+    // check_consistency(shared, &pattern);
 
 
     Some (pattern)

--- a/src/expand_variable.rs
+++ b/src/expand_variable.rs
@@ -98,11 +98,10 @@ pub fn perform_expansion_variable(
     let mut expands_to = expands_to;
 
 
-    // check_consistency(shared, &pattern);
+    check_consistency(shared, &pattern);
     // println!("expands_to: {:?}", expands_to);
     // println!("pattern: {:?}", pattern);
     // update the body utility
-    let body_utility = pattern.body_utility +  compute_body_utility_change(shared, &expands_to);
 
     // assert!(shared.cfg.no_opt_upper_bound || !holes_after_pop.is_empty() || !original_pattern.arg_choices.is_empty() || expands_to.has_holes() || expands_to.is_ivar(),
             // "unexpected arity 0 invention: upper bounds + priming with arity 0 inventions should have prevented this");
@@ -112,12 +111,14 @@ pub fn perform_expansion_variable(
     // build our new pattern with all the variables we've just defined. Copy in the argchoices and prefixes
     // from the old pattern.
     // new_pattern.match_locations = locs;
-    pattern.body_utility = body_utility;
 
     // println!("targeting ivar: {}", variable_ivar);
     // println!("expands_to: {:?}", expands_to);
     // println!("original: {:?}", new_pattern);
     let variable_zids: Vec<usize> = remove_variable_at(&mut pattern, variable_ivar, &mut expands_to);
+
+    let body_utility = pattern.body_utility +  compute_body_utility_change(shared, &expands_to) * variable_zids.len() as i32;
+    pattern.body_utility = body_utility;
 
     // println!("pattern after remove: {:?}", pattern);
     // println!("expands_to after remove: {:?}", expands_to);
@@ -150,7 +151,7 @@ pub fn perform_expansion_variable(
 
     // println!("after adding variable: {:?}", new_pattern);
 
-    // check_consistency(shared, &pattern);
+    check_consistency(shared, &pattern);
 
 
     Some (pattern)

--- a/src/expand_variable.rs
+++ b/src/expand_variable.rs
@@ -7,7 +7,7 @@ pub fn add_variable_at(p: &mut Pattern, at_loc: usize, var_id: i32) {
     }
 }
 
-pub fn remove_variable_at(p: &mut Pattern, var_id: usize) -> Vec<ZId> {
+pub fn remove_variable_at(p: &mut Pattern, var_id: usize, expands_to: &mut ExpandsTo) -> Vec<ZId> {
     let mut zids = Vec::new();
     // remove the variable from the arg choices
     p.arg_choices.retain(|x: &LabelledZId| {
@@ -24,6 +24,12 @@ pub fn remove_variable_at(p: &mut Pattern, var_id: usize) -> Vec<ZId> {
             x.ivar -= 1; // decrement the ivar index for all variables after the one we're removing
         }
     });
+    if let ExpandsTo::IVar(i) = expands_to {
+        assert!(*i != var_id as i32, "ExpandsTo::IVar should not be the variable we're removing");
+        if *i > var_id as i32 {
+            *i -= 1;
+        }
+    }
     // remove the variable from the first_zid_of_ivar
     p.first_zid_of_ivar.remove(var_id);
     zids
@@ -46,7 +52,25 @@ pub fn check_consistency(shared: &SharedData, p: &Pattern) {
         // check that the ivar is within bounds
         let arg_of_loc = &shared.arg_of_zid_node[labeled.zid];
         for loc in p.match_locations.iter() {
-            assert!(arg_of_loc.contains_key(loc), "Variable {} at location {} is not consistent with shared data", labeled.ivar, loc);
+            assert!(arg_of_loc.contains_key(loc), "Variable id={}, zid={} at location {} is not consistent with shared data", labeled.ivar, labeled.zid, loc);
+        }
+    }
+    for (ivar, zid) in p.first_zid_of_ivar.iter().enumerate() {
+        for labeled in p.arg_choices.iter() {
+            if labeled.ivar == ivar {
+                // check that they expand to the same thing
+                let arg_of_loc_1 = &shared.arg_of_zid_node[labeled.zid];
+                let arg_of_loc_2 = &shared.arg_of_zid_node[*zid];
+                // println!("Checking consistency for variable id={} (zid={} vs zid={})", ivar, zid, labeled.zid);
+                for loc in p.match_locations.iter() {
+                    assert!(arg_of_loc_1.contains_key(loc) && arg_of_loc_2.contains_key(loc), 
+                        "Variable id={} at location {} is not consistent with shared data: {:?} vs {:?}", ivar, loc, arg_of_loc_1.get(loc), arg_of_loc_2.get(loc));
+                    assert_eq!(arg_of_loc_1[loc].shifted_id, arg_of_loc_2[loc].shifted_id,
+                        "Variable id={} at location {} has different shifted ids: {} vs {}", ivar, loc, arg_of_loc_1[loc].shifted_id, arg_of_loc_2[loc].shifted_id);
+                    assert_eq!(arg_of_loc_1[loc].expands_to, arg_of_loc_2[loc].expands_to,
+                        "Variable id={} at location {} expands to different things: {} vs {}", ivar, loc, arg_of_loc_1[loc].expands_to, arg_of_loc_2[loc].expands_to);
+                }
+            }
         }
     }
     // for i in 0..num_vars {
@@ -71,9 +95,12 @@ pub fn perform_expansion_variable(
     // if tracked { found_tracked = true; }
     // if shared.cfg.follow_prune && !tracked { return None; }
     let mut pattern = pattern;
+    let mut expands_to = expands_to;
 
 
-    // check_consistency(shared, original_pattern);
+    // check_consistency(shared, &pattern);
+    // println!("expands_to: {:?}", expands_to);
+    // println!("pattern: {:?}", pattern);
     // update the body utility
     let body_utility = pattern.body_utility +  compute_body_utility_change(shared, &expands_to);
 
@@ -90,7 +117,11 @@ pub fn perform_expansion_variable(
     // println!("targeting ivar: {}", variable_ivar);
     // println!("expands_to: {:?}", expands_to);
     // println!("original: {:?}", new_pattern);
-    let variable_zids: Vec<usize> = remove_variable_at(&mut pattern, variable_ivar);
+    let variable_zids: Vec<usize> = remove_variable_at(&mut pattern, variable_ivar, &mut expands_to);
+
+    // println!("pattern after remove: {:?}", pattern);
+    // println!("expands_to after remove: {:?}", expands_to);
+    // println!("variable_zids: {:?}", variable_zids);
     // println!("after removing variable: {:?}", new_pattern);
     // println!("variable_zids: {:?}", variable_zids);
 
@@ -115,10 +146,11 @@ pub fn perform_expansion_variable(
             add_variable_at(&mut pattern, variable_zid, i);
         }
     }
+    // println!("pattern after add: {:?}", pattern);
 
     // println!("after adding variable: {:?}", new_pattern);
 
-    // check_consistency(shared, &new_pattern);
+    // check_consistency(shared, &pattern);
 
 
     Some (pattern)

--- a/src/smc.rs
+++ b/src/smc.rs
@@ -4,7 +4,67 @@ use rand::SeedableRng;
 use rustc_hash::{FxHashMap};
 use std::sync::Arc;
 
-const P_REUSE: f64 = 0.2;
+fn sample_new_ivar(
+    original_pattern: &Pattern,
+    shared: &SharedData,
+    variable_ivar: usize,
+    match_loc: &usize,
+    rng: &mut impl rand::Rng,
+) -> Option<usize> {
+    let num_vars = get_num_variables(original_pattern);
+    if num_vars <= 1 {
+        return None; // no other variable to expand to
+    }
+    let mut new_ivar = rng.gen_range(0..num_vars - 1);
+    if new_ivar >= variable_ivar {
+        new_ivar += 1; // skip the variable we are expanding
+    }
+    let zid_original = get_zid_for_ivar(original_pattern, variable_ivar);
+    let zid_new = get_zid_for_ivar(original_pattern, new_ivar);
+    if shared.arg_of_zid_node[zid_original][match_loc].shifted_id == shared.arg_of_zid_node[zid_new][match_loc].shifted_id {
+        return Some(new_ivar);
+    }
+    return None;
+}
+
+fn sample_variable_reuse(
+    pattern: &Pattern,
+    shared: &SharedData,
+    variable_ivar: usize,
+    match_location: usize,
+    rng: &mut impl rand::Rng,
+) -> Option<(Pattern, ExpandsTo)> {
+    if let Some(new_ivar) = sample_new_ivar(pattern, shared, variable_ivar, &match_location, rng) {
+        let zid_original = get_zid_for_ivar(pattern, variable_ivar);
+        let zid_new = get_zid_for_ivar(pattern, new_ivar);
+        let locs = compatible_locations(
+            shared,
+            pattern,
+            &shared.arg_of_zid_node[zid_original],
+            &shared.arg_of_zid_node[zid_new],
+        );
+        if !locs.is_empty() {
+            let mut pattern = pattern.clone();
+            pattern.match_locations = locs;
+            let expands_to = ExpandsTo::IVar(new_ivar as i32);
+            return Some((pattern, expands_to));
+        }
+    }
+    None
+}
+
+fn sample_syntactic_expansion(
+    original_pattern: &Pattern,
+    arg_of_loc: &FxHashMap<Idx, Arg>,
+    match_location: usize,
+) -> (Pattern, ExpandsTo) {
+    let mut pattern = original_pattern.clone();
+    let expands_to = arg_of_loc[&match_location].expands_to.clone();
+    pattern.match_locations.retain(
+        |loc| arg_of_loc[&loc].expands_to == expands_to
+    );
+    return (pattern, expands_to);
+}
 
 fn sample_expands_to(
     original_pattern: &Pattern,
@@ -14,50 +74,20 @@ fn sample_expands_to(
     variable_ivar: usize,
     rng: &mut impl rand::Rng,
 ) -> (Pattern, ExpandsTo) {
-    let mut pattern = original_pattern.clone();
-    if get_num_variables(original_pattern) > 1 && rng.gen::<f64>() < P_REUSE {
-        let mut new_ivar = rng.gen_range(0..get_num_variables(original_pattern) - 1);
-        if new_ivar >= variable_ivar {
-            new_ivar += 1; // skip the variable we are expanding
-        }
-        let zid_original = get_zid_for_ivar(original_pattern, variable_ivar);
-        let zid_new = get_zid_for_ivar(original_pattern, new_ivar);
-        let locs = compatible_locations(
-            shared,
-            original_pattern,
-            &shared.arg_of_zid_node[zid_original],
-            &shared.arg_of_zid_node[zid_new],
-        );
-        if !locs.is_empty() {
-            pattern.match_locations = locs;
-            let expands_to = ExpandsTo::IVar(new_ivar as i32);
-            return (pattern, expands_to);
-        }
-        // let mut results: Vec<(ExpandsTo, Vec<usize>)> = get_ivars_variable_reuse(
-        //     original_pattern,
-        //     arg_of_loc,
-        //     shared,
-        // );
-        // results.retain(|(expands_to, _)| {
-        //     // filter out expansions that are not valid for the current match location
-        //     if let ExpandsTo::IVar(ivar) = expands_to {
-        //         if *ivar == variable_ivar as i32 {
-        //             return false; // don't reuse the same variable
-        //         }
-        //     }
-        //     return true;
-        // });
-        // if !results.is_empty() {
-        //     let (expands_to, locs) = &results[rng.gen_range(0..results.len())];
-        //     pattern.match_locations = locs.clone();
-        //     return (pattern, expands_to.clone());
-        // }
+    if let Some(out) = sample_variable_reuse(
+        original_pattern,
+        shared,
+        variable_ivar,
+        match_location,
+        rng,
+    ) {
+        return out;
     }
-    let expands_to = arg_of_loc[&match_location].expands_to.clone();
-    pattern.match_locations.retain(
-        |loc| arg_of_loc[&loc].expands_to == expands_to
+    return sample_syntactic_expansion(
+        original_pattern,
+        arg_of_loc,
+        match_location,
     );
-    return (pattern, expands_to);
 }
 
 pub fn smc_expand(


### PR DESCRIPTION
Baseline on wheels

Found 3 inventions
Cost Improvement: (1.67x better) 3577776 -> 2140344
fn_0 (1.24x wrt orig): utility: 699628 | final_cost: 2877846 | 1.24x | uses: 3465 | body: [fn_0 arity=0: (M 1 0)]
fn_1 (1.46x wrt orig): utility: 418442 | final_cost: 2458898 | 1.17x | uses: 1037 | body: [fn_1 arity=2: (T #1 (M #0 0 0 0))]
fn_2 (1.67x wrt orig): utility: 318250 | final_cost: 2140344 | 1.15x | uses: 1577 | body: [fn_2 arity=2: (T #1 (fn_0 #0 0))]
Time: 346ms
