### PR TITLE
more general syntactic expansion

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1007,7 +1007,7 @@ fn stitch_search(
 
                 // add any new holes to the list of holes
                 let mut holes = holes_after_pop.clone();
-                expands_to.add_holes(&shared.extensions_of_zid[hole_zid], &mut holes);
+                expands_to.syntactic_expansion(&shared.extensions_of_zid[hole_zid], |zid, _| holes.push(zid));
 
                 // update arg_choices and possibly variables if a new ivar was added
                 let mut pattern_args = original_pattern.pattern_args.clone();

--- a/src/expansion.rs
+++ b/src/expansion.rs
@@ -82,17 +82,15 @@ impl ExpandsTo {
     }
 
     #[inline]
-    pub fn add_holes(&self, original_hole_zid_extension: &ZIdExtension, holes: &mut Vec<ZId>) {
+    pub fn syntactic_expansion<F>(&self, original_hole_zid_extension: &ZIdExtension, mut func: F) where F: FnMut(ZId, usize) {
         let ExpandsTo(expands_to) = self;
         match expands_to {
             ExpandsToInner::Lam(_) => {
-                // add new holes
-                holes.push(original_hole_zid_extension.body.unwrap());
+                func(original_hole_zid_extension.body.unwrap(), 0);
             }
             ExpandsToInner::App => {
-                // add new holes
-                    holes.push(original_hole_zid_extension.func.unwrap());
-                    holes.push(original_hole_zid_extension.arg.unwrap());
+                func(original_hole_zid_extension.func.unwrap(), 0);
+                func(original_hole_zid_extension.arg.unwrap(), 1);
             }
             _ => {}
         }


### PR DESCRIPTION
Before: Summary (95% CI, arithmetic mean): 1147.83 [1146.39, 1149.14]
After: Summary (95% CI, arithmetic mean): 1150.06 [1146.03, 1154.68]

No real difference in performance