### PR TITLE
correctly propagate the variable type when reusing variables

### DIFF
--- a/src/expansion.rs
+++ b/src/expansion.rs
@@ -187,7 +187,7 @@ pub fn get_ivars_expansions(original_pattern: &Pattern, arg_of_loc: &FxHashMap<I
         let locs = original_pattern.pattern_args.reusable_args_location(shared, var, arg_of_loc, &mut locs_for_reusable);
         if locs.is_empty() { continue; }
         all_reusable_locs.extend(locs.iter().cloned());
-        ivars_expansions.push((ExpandsTo(ExpandsToInner::IVar(var as i32, VariableType::Metavar)), locs));
+        ivars_expansions.push((ExpandsTo(ExpandsToInner::IVar(var as i32, original_pattern.pattern_args.type_of(var))), locs));
     }
     // also consider one ivar greater, if this is within the arity limit. This will match at all the same locations as the original.
     if original_pattern.pattern_args.num_ivars() < shared.cfg.max_arity {

--- a/src/pattern_args.rs
+++ b/src/pattern_args.rs
@@ -58,6 +58,10 @@ impl PatternArgs {
         }
     }
 
+    pub fn type_of(&self, ivar: usize) -> VariableType {
+        self.variables[ivar].1
+    }
+
     fn zippers(&self, shared: &SharedData) -> Vec<Vec<ZNode>> {
         self.arg_choices.iter().map(|lzid|
             shared.zip_of_zid[lzid.zid].clone()


### PR DESCRIPTION
Effect on main

before: Summary (95% CI, arithmetic mean): 1026.19 [1024.30, 1028.21]
after: Summary (95% CI, arithmetic mean): 1038.05 [1035.61, 1040.66]

+1.5%

Effect on smc

before: Summary (95% CI, arithmetic mean): 1401.27 [1397.58, 1404.95]
after: Summary (95% CI, arithmetic mean): 1404.24 [1401.44, 1407.39]

+0.2%

This has not a huge effect, and it's more consistent, even if not strictly necessary